### PR TITLE
feat: make weather widget location configurable via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@ AUTH_SECRET=generate-a-random-32-char-string-here
 # OPENCLAW_DIR=/root/.openclaw
 # OPENCLAW_WORKSPACE=/root/.openclaw/workspace
 
+# Weather widget location (defaults to Madrid if not set)
+# Find your timezone at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# WEATHER_LAT=40.4168
+# WEATHER_LON=-3.7038
+# WEATHER_CITY=Madrid
+# WEATHER_TIMEZONE=Europe/Madrid
+
 # Branding (customize for your instance)
 NEXT_PUBLIC_AGENT_NAME=Mission Control
 NEXT_PUBLIC_AGENT_EMOJI=🤖

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,11 @@ yarn-error.log*
 /data/*.json
 !data/*.example.json
 /data/*.db
+/data/*.db-shm
+/data/*.db-wal
 /data/*.sqlite
+/data/*.sqlite-shm
+/data/*.sqlite-wal
 /data/*.sqlite3
 
 # vercel

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -39,9 +39,13 @@ export async function GET() {
     return NextResponse.json(cache.data);
   }
 
+  const lat = process.env.WEATHER_LAT ?? '40.4168';
+  const lon = process.env.WEATHER_LON ?? '-3.7038';
+  const city = process.env.WEATHER_CITY ?? 'Madrid';
+  const timezone = process.env.WEATHER_TIMEZONE ?? 'Europe/Madrid';
+
   try {
-    // Madrid coordinates: 40.4168° N, 3.7038° W
-    const url = 'https://api.open-meteo.com/v1/forecast?latitude=40.4168&longitude=-3.7038&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,wind_speed_10m,precipitation&daily=temperature_2m_max,temperature_2m_min,weather_code&timezone=Europe%2FMadrid&forecast_days=3';
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,wind_speed_10m,precipitation&daily=temperature_2m_max,temperature_2m_min,weather_code&timezone=${encodeURIComponent(timezone)}&forecast_days=3`;
 
     const res = await fetch(url, { next: { revalidate: 600 } });
     const json = await res.json();
@@ -52,7 +56,7 @@ export async function GET() {
     const wmo = WMO_CODES[current.weather_code] || { label: "Unknown", emoji: "🌡️" };
 
     const data = {
-      city: "Madrid",
+      city,
       temp: Math.round(current.temperature_2m),
       feels_like: Math.round(current.apparent_temperature),
       humidity: current.relative_humidity_2m,


### PR DESCRIPTION
## Summary

  - Replace hardcoded Madrid coordinates in `/api/weather` with `WEATHER_LAT`, `WEATHER_LON`, `WEATHER_CITY` and `WEATHER_TIMEZONE` env vars
  - Defaults to Madrid if the variables are not set
  - Update `.env.example` with documentation and link to timezone list
  - Add SQLite WAL/SHM auxiliary files (`*.db-shm`, `*.db-wal`) to `.gitignore`