### PR TITLE
fix(agents): derive online status from sessions activity instead of daily memory file

### DIFF
--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { readFileSync } from "fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 
 export const dynamic = "force-dynamic";
@@ -55,10 +55,46 @@ function getAgentDisplayInfo(agentId: string, agentConfig: any): { emoji: string
   };
 }
 
+function getLatestMtimeIsoFromDir(dirPath: string, fileFilter: (name: string) => boolean): string | undefined {
+  if (!existsSync(dirPath)) return undefined;
+
+  let latest = 0;
+  const files = readdirSync(dirPath);
+  for (const name of files) {
+    if (!fileFilter(name)) continue;
+    try {
+      const fullPath = join(dirPath, name);
+      const stat = statSync(fullPath);
+      const mtimeMs = stat.mtime.getTime();
+      if (mtimeMs > latest) latest = mtimeMs;
+    } catch {
+      // ignore transient file errors
+    }
+  }
+
+  return latest > 0 ? new Date(latest).toISOString() : undefined;
+}
+
+function getAgentLastActivity(agentId: string, workspace?: string, openclawDir?: string): string | undefined {
+  // 1) Prefer sessions activity (actual chat traffic, near real-time)
+  const sessionsDir = join(openclawDir || "/root/.openclaw", "agents", agentId, "sessions");
+  const latestSessionActivity = getLatestMtimeIsoFromDir(
+    sessionsDir,
+    (name) => name.endsWith(".jsonl") || name.endsWith(".jsonl.lock") || name === "sessions.json"
+  );
+  if (latestSessionActivity) return latestSessionActivity;
+
+  // 2) Fallback to memory activity (if sessions data is unavailable)
+  if (!workspace) return undefined;
+  const memoryDir = join(workspace, "memory");
+  return getLatestMtimeIsoFromDir(memoryDir, (name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name));
+}
+
 export async function GET() {
   try {
     // Read openclaw config
-    const configPath = (process.env.OPENCLAW_DIR || "/root/.openclaw") + "/openclaw.json";
+    const openclawDir = process.env.OPENCLAW_DIR || "/root/.openclaw";
+    const configPath = openclawDir + "/openclaw.json";
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
 
     // Get agents from config
@@ -66,36 +102,21 @@ export async function GET() {
       const agentInfo = getAgentDisplayInfo(agent.id, agent);
 
       // Get telegram account info
-      const telegramAccount =
-        config.channels?.telegram?.accounts?.[agent.id];
+      const telegramAccount = config.channels?.telegram?.accounts?.[agent.id];
       const botToken = telegramAccount?.botToken;
 
       // Check if agent has recent activity
-      const memoryPath = join(agent.workspace, "memory");
-      let lastActivity = undefined;
-      let status: "online" | "offline" = "offline";
-
-      try {
-        const today = new Date().toISOString().split("T")[0];
-        const memoryFile = join(memoryPath, `${today}.md`);
-        const stat = require("fs").statSync(memoryFile);
-        lastActivity = stat.mtime.toISOString();
-        // Consider online if activity within last 5 minutes
-        status =
-          Date.now() - stat.mtime.getTime() < 5 * 60 * 1000
-            ? "online"
-            : "offline";
-      } catch (e) {
-        // No recent activity
-      }
+      const lastActivity = getAgentLastActivity(agent.id, agent.workspace, openclawDir);
+      const status: "online" | "offline" =
+        lastActivity && Date.now() - new Date(lastActivity).getTime() < 5 * 60 * 1000
+          ? "online"
+          : "offline";
 
       // Get details of allowed subagents
       const allowAgents = agent.subagents?.allowAgents || [];
       const allowAgentsDetails = allowAgents.map((subagentId: string) => {
         // Find subagent in config
-        const subagentConfig = config.agents.list.find(
-          (a: any) => a.id === subagentId
-        );
+        const subagentConfig = config.agents.list.find((a: any) => a.id === subagentId);
         if (subagentConfig) {
           const subagentInfo = getAgentDisplayInfo(subagentId, subagentConfig);
           return {
@@ -120,13 +141,9 @@ export async function GET() {
         name: agent.name || agentInfo.name,
         emoji: agentInfo.emoji,
         color: agentInfo.color,
-        model:
-          agent.model?.primary || config.agents.defaults.model.primary,
+        model: agent.model?.primary || config.agents.defaults.model.primary,
         workspace: agent.workspace,
-        dmPolicy:
-          telegramAccount?.dmPolicy ||
-          config.channels?.telegram?.dmPolicy ||
-          "pairing",
+        dmPolicy: telegramAccount?.dmPolicy || config.channels?.telegram?.dmPolicy || "pairing",
         allowAgents,
         allowAgentsDetails,
         botToken: botToken ? "configured" : undefined,
@@ -139,9 +156,6 @@ export async function GET() {
     return NextResponse.json({ agents });
   } catch (error) {
     console.error("Error reading agents:", error);
-    return NextResponse.json(
-      { error: "Failed to load agents" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to load agents" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes incorrect `offline` status in the **Agents** page.

Previously, agent status was inferred from `memory/YYYY-MM-DD.md` mtime, which is fragile and can report false offline states (timezone/date rollover, no daily memory write, etc.).

Now status is computed from real session activity under:
- `~/.openclaw/agents/<agentId>/sessions/*.jsonl`
- `~/.openclaw/agents/<agentId>/sessions/*.jsonl.lock`
- `~/.openclaw/agents/<agentId>/sessions/sessions.json`

If session activity is not available, it falls back to memory activity.

## What changed
- Updated `src/app/api/agents/route.ts`
- Added latest-mtime helper for directory files.
- Added `getAgentLastActivity(...)`:
1) prefer sessions activity
2) fallback to memory activity
- Keep current online threshold logic (`< 5 minutes`).

## Why
Users can be actively chatting with an agent while the dashboard still shows all agents as offline.
Using sessions files reflects real traffic and fixes these false negatives.

## How to test
1. Open Mission Control and go to **Agents**.
2. Send messages to an agent (or interact in an active session).
3. Refresh Agents page.
4. Agent should appear **online** when recent activity exists.
5. Wait >5 minutes without activity and confirm it turns **offline**.

## Notes
- No UI changes.
- Backward-compatible fallback to memory remains in place.
