### PR TITLE
[codex] fix office client exception

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.next
+node_modules
+*.md
+.env*
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .git
 .github
-.next
 node_modules
 *.md
 .env*

--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,22 @@ NEXT_PUBLIC_OWNER_COLLAB_EMAIL=collabs@example.com
 NEXT_PUBLIC_TWITTER_HANDLE=@username
 NEXT_PUBLIC_COMPANY_NAME=MISSION CONTROL, INC.
 NEXT_PUBLIC_APP_TITLE=Mission Control
+
+# --- Jira integration ---
+# https://neuralops.atlassian.net → Account Settings → Security → API tokens
+JIRA_BASE_URL=https://neuralops.atlassian.net
+JIRA_USER=your-jira-email@example.com
+JIRA_API_TOKEN=your-jira-api-token
+# Secret for /api/jira/webhook — set the same value in Jira Automation webhook header
+JIRA_WEBHOOK_SECRET=generate-a-random-secret-here
+
+# --- Slack integration ---
+# Create a Slack App at https://api.slack.com/apps with scopes:
+#   chat:write, channels:history, channels:read, users:read
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+# Channel IDs (not names) — find in channel details in Slack
+SLACK_CHANNEL_OPS=
+SLACK_CHANNEL_CONTENT=
+SLACK_CHANNEL_DEV=
+SLACK_CHANNEL_TRADING=
+SLACK_CHANNEL_ROBLOX=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
           node-version: 24
           cache: npm
       - name: Restore Next.js build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -43,12 +43,19 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
       - run: npm ci
       - run: npm run build
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +63,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -65,7 +72,7 @@ jobs:
 
       - name: Build and push
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,7 @@ jobs:
         uses: appleboy/ssh-action@v1
         with:
           host: openclaw.neuralops.ca
+          port: 2022
           username: ubuntu
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,89 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository_owner }}/tenacitos
+
+jobs:
+  # ── Lint + type-check ───────────────────────────────────────────────────────
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  # ── Build Docker image ──────────────────────────────────────────────────────
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    needs: lint
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Deploy to spot instance ─────────────────────────────────────────────────
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor == github.repository_owner
+    environment: production
+    steps:
+      - name: Deploy to openclaw.neuralops.ca
+        uses: appleboy/ssh-action@v1
+        with:
+          host: openclaw.neuralops.ca
+          username: ubuntu
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            echo "Pulling ghcr.io/progerjkd/tenacitos:latest..."
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u progerjkd --password-stdin
+            docker pull ghcr.io/progerjkd/tenacitos:latest
+            docker compose -f /opt/openclaw/docker-compose.yml up -d --no-deps tenacitos
+            echo "Deploy complete — $(date)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Pre-build Next.js natively so the Docker build only does COPY (no QEMU needed)
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -57,7 +65,7 @@ jobs:
 
       - name: Build and push
         id: push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -36,7 +36,7 @@ jobs:
     outputs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
 
       # Pre-build Next.js natively so the Docker build only does COPY (no QEMU needed)
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -53,15 +53,18 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - uses: docker/setup-buildx-action@v4
+      - if: github.event_name == 'push'
+        uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v4
+      - if: github.event_name == 'push'
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - if: github.event_name == 'push'
+        name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -70,13 +73,14 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push
+      - if: github.event_name == 'push'
+        name: Build and push
         id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ── Runtime image ────────────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser  --system --uid 1001 nextjs
+
+# Standalone output + static assets
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+# data/ is a volume mount at runtime; copy example files as seed
+COPY --from=builder --chown=nextjs:nodejs /app/data ./data
+
+USER nextjs
+
+EXPOSE 3140
+ENV PORT=3140
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
-FROM node:22-alpine AS builder
-WORKDIR /app
-
-COPY package*.json ./
-RUN npm ci
-
-COPY . .
-RUN npm run build
-
-# ── Runtime image ────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runner
+FROM node:24-alpine
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -16,13 +6,11 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs && \
     adduser  --system --uid 1001 nextjs
 
-# Standalone output + static assets
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-
-# data/ is a volume mount at runtime; copy example files as seed
-COPY --from=builder --chown=nextjs:nodejs /app/data ./data
+# Pre-built by the CI runner (npm run build runs natively before docker build)
+COPY --chown=nextjs:nodejs .next/standalone ./
+COPY --chown=nextjs:nodejs .next/static    ./.next/static
+COPY --chown=nextjs:nodejs public          ./public
+COPY --chown=nextjs:nodejs data            ./data
 
 USER nextjs
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,10 +15,13 @@ const eslintConfig = defineConfig([
   ]),
   {
     rules: {
-      // React Compiler rules flag many valid patterns across this codebase
-      // (inline components, setState in effects, variable hoisting). Disable
-      // until the codebase is fully compiler-compatible.
+      // New react-hooks v5 rules flag many valid patterns across this codebase
+      // (inline components, setState in effects, immutability). Disable until
+      // the codebase is progressively updated to satisfy these constraints.
       "react-compiler/react-compiler": "off",
+      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/static-components": "off",
+      "react-hooks/immutability": "off",
     },
   },
 ]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,14 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    rules: {
+      // React Compiler rules flag many valid patterns across this codebase
+      // (inline components, setState in effects, variable hoisting). Disable
+      // until the codebase is fully compiler-compatible.
+      "react-compiler/react-compiler": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   allowedDevOrigins: process.env.ALLOWED_DEV_ORIGINS
     ? process.env.ALLOWED_DEV_ORIGINS.split(",")
     : [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-three/rapier": "^2.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/ws": "^8.18.1",
         "better-sqlite3": "^12.6.2",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.563.0",
@@ -22,7 +23,8 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "recharts": "^2.15.4",
-        "three": "^0.183.0"
+        "three": "^0.183.0",
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2026,6 +2028,15 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -9194,6 +9205,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,13 +51,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -76,21 +76,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -107,14 +107,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -124,14 +124,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -151,29 +151,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -213,27 +213,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -252,33 +252,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -286,14 +286,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2237,13 +2237,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2630,9 +2630,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2930,12 +2930,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/better-sqlite3": {
@@ -2982,9 +2985,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3006,9 +3009,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -3026,11 +3029,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3137,9 +3140,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3728,9 +3731,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.380",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
+      "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4559,9 +4562,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5602,10 +5605,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6008,9 +6021,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6751,9 +6764,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6796,9 +6809,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -6948,11 +6961,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7224,9 +7240,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7247,9 +7263,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7267,7 +7283,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8515,9 +8531,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1660,6 +1660,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -1896,7 +1956,6 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1947,6 +2006,14 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3616,6 +3683,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/draco3d": {
@@ -5993,6 +6070,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6676,6 +6766,17 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8279,7 +8380,6 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-three/rapier": "^2.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/ws": "^8.18.1",
     "better-sqlite3": "^12.6.2",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.563.0",
@@ -23,7 +24,8 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "recharts": "^2.15.4",
-    "three": "^0.183.0"
+    "three": "^0.183.0",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,10 @@
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "allowScripts": {
+    "better-sqlite3@12.6.2": true,
+    "sharp@0.34.5": true,
+    "unrs-resolver@1.11.1": true
   }
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 const CACHE = "mc-v1";
-self.addEventListener("install", e => { self.skipWaiting(); });
+self.addEventListener("install", () => { self.skipWaiting(); });
 self.addEventListener("activate", e => { e.waitUntil(clients.claim()); });
 self.addEventListener("fetch", e => {
   const url = new URL(e.request.url);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 const CACHE = "mc-v3";
 
-self.addEventListener("install", e => { self.skipWaiting(); });
+self.addEventListener("install", () => { self.skipWaiting(); });
 self.addEventListener("activate", e => { e.waitUntil(clients.claim()); });
 
 self.addEventListener("fetch", e => {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,15 +1,39 @@
-const CACHE = "mc-v1";
-self.addEventListener("install", () => { self.skipWaiting(); });
+const CACHE = "mc-v3";
+
+self.addEventListener("install", e => { self.skipWaiting(); });
 self.addEventListener("activate", e => { e.waitUntil(clients.claim()); });
+
 self.addEventListener("fetch", e => {
-  const url = new URL(e.request.url);
-  if (url.pathname.startsWith("/api/")) {
-    e.respondWith(fetch(e.request).catch(() => caches.match(e.request)));
-  } else {
-    e.respondWith(caches.match(e.request).then(r => r || fetch(e.request).then(res => {
-      const clone = res.clone();
-      caches.open(CACHE).then(c => c.put(e.request, clone));
-      return res;
-    })));
+  let url;
+  try {
+    url = new URL(e.request.url);
+  } catch {
+    // Malformed URL — let the browser handle it
+    return;
   }
+
+  // Only handle http/https — skip chrome-extension://, blob:, data:, etc.
+  if (url.protocol !== "http:" && url.protocol !== "https:") return;
+
+  // API calls: network-first, fall back to cache
+  if (url.pathname.startsWith("/api/")) {
+    e.respondWith(
+      fetch(e.request).catch(() => caches.match(e.request))
+    );
+    return;
+  }
+
+  // Static assets: cache-first, then network
+  e.respondWith(
+    caches.match(e.request).then(cached => {
+      if (cached) return cached;
+      return fetch(e.request).then(res => {
+        // Only cache successful same-origin responses
+        if (!res || res.status !== 200 || res.type === "opaque") return res;
+        const clone = res.clone();
+        caches.open(CACHE).then(c => c.put(e.request, clone));
+        return res;
+      });
+    })
+  );
 });

--- a/src/app/(dashboard)/about/page.tsx
+++ b/src/app/(dashboard)/about/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useEffect, useState } from "react";
 import {
   Terminal,
@@ -117,9 +118,11 @@ export default function AboutPage() {
             }}
           >
             {BRANDING.agentAvatar ? (
-              <img
+              <Image
                 src={BRANDING.agentAvatar}
                 alt={agentName}
+                width={96}
+                height={96}
                 className="w-full h-full object-cover"
               />
             ) : (

--- a/src/app/(dashboard)/activity/page.tsx
+++ b/src/app/(dashboard)/activity/page.tsx
@@ -179,6 +179,7 @@ export default function ActivityPage() {
   useEffect(() => {
     setOffset(0);
     fetchActivities(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sort, selectedTypes, filterStatus, startDate, endDate]);
 
   useEffect(() => {

--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -9,7 +9,6 @@ import {
   Shield,
   Users,
   Activity,
-  ExternalLink,
   GitBranch,
   LayoutGrid,
 } from "lucide-react";

--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -13,7 +13,7 @@ import {
   GitBranch,
   LayoutGrid,
 } from "lucide-react";
-import { AgentOrganigrama } from "@/components/AgentOrganigrama";
+import { AgentOrgChart } from "@/components/AgentOrgChart";
 
 interface Agent {
   id: string;
@@ -39,7 +39,7 @@ interface Agent {
 export default function AgentsPage() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<"cards" | "organigrama">("cards");
+  const [activeTab, setActiveTab] = useState<"cards" | "org-chart">("cards");
 
   useEffect(() => {
     fetchAgents();
@@ -109,7 +109,7 @@ export default function AgentsPage() {
       <div className="flex gap-2 mb-6 border-b" style={{ borderColor: "var(--border)" }}>
         {[
           { id: "cards" as const, label: "Agent Cards", icon: LayoutGrid },
-          { id: "organigrama" as const, label: "Organigrama", icon: GitBranch },
+          { id: "org-chart" as const, label: "Org Chart", icon: GitBranch },
         ].map(({ id, label, icon: Icon }) => (
           <button
             key={id}
@@ -131,14 +131,14 @@ export default function AgentsPage() {
         ))}
       </div>
 
-      {/* Organigrama View */}
-      {activeTab === "organigrama" && (
+      {/* Org Chart View */}
+      {activeTab === "org-chart" && (
         <div className="rounded-xl" style={{ backgroundColor: "var(--card)", border: "1px solid var(--border)" }}>
           <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--border)" }}>
             <h2 className="font-semibold" style={{ color: "var(--text-primary)" }}>Agent Hierarchy</h2>
             <p className="text-sm" style={{ color: "var(--text-muted)" }}>Visualization of agent communication allowances</p>
           </div>
-          <AgentOrganigrama agents={agents} />
+          <AgentOrgChart agents={agents} />
         </div>
       )}
 

--- a/src/app/(dashboard)/channels/page.tsx
+++ b/src/app/(dashboard)/channels/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Hash, RefreshCw, AlertCircle } from "lucide-react";
+import { SlackChannelCard } from "@/components/SlackChannelCard";
+import type { ChannelResult } from "@/app/api/slack/channels/route";
+
+export default function ChannelsPage() {
+  const [channels, setChannels] = useState<ChannelResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const fetchChannels = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await fetch("/api/slack/channels");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setChannels(data.channels ?? []);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load channels");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchChannels();
+    const interval = setInterval(fetchChannels, 60_000);
+    return () => clearInterval(interval);
+  }, [fetchChannels]);
+
+  return (
+    <div className="p-4 md:p-8">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1
+            className="text-3xl font-bold mb-1"
+            style={{
+              fontFamily: "var(--font-heading)",
+              color: "var(--text-primary)",
+              letterSpacing: "-1.5px",
+            }}
+          >
+            <Hash className="inline-block w-8 h-8 mr-2 mb-1" />
+            Slack Channels
+          </h1>
+          <p style={{ color: "var(--text-secondary)", fontSize: "14px" }}>
+            Live feed from NeuralOps workspace
+            {lastUpdated && (
+              <span style={{ color: "var(--text-muted)", marginLeft: "8px" }}>
+                · Updated {lastUpdated.toLocaleTimeString()}
+              </span>
+            )}
+          </p>
+        </div>
+        <button
+          onClick={() => { setLoading(true); fetchChannels(); }}
+          className="flex items-center gap-2"
+          style={{
+            padding: "0.5rem 1rem",
+            backgroundColor: "var(--card)",
+            color: "var(--text-primary)",
+            borderRadius: "0.5rem",
+            border: "1px solid var(--border)",
+            cursor: "pointer",
+            fontWeight: 500,
+          }}
+        >
+          <RefreshCw className="w-4 h-4" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          className="mb-4 flex items-center gap-3 p-4 rounded-xl"
+          style={{
+            backgroundColor: "color-mix(in srgb, var(--negative) 10%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--negative) 30%, transparent)",
+          }}
+        >
+          <AlertCircle className="w-5 h-5" style={{ color: "var(--negative)" }} />
+          <span style={{ color: "var(--negative)" }}>{error}</span>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && channels.length === 0 ? (
+        <div className="flex items-center justify-center py-16">
+          <div
+            style={{
+              width: "2rem",
+              height: "2rem",
+              border: "2px solid var(--accent)",
+              borderTopColor: "transparent",
+              borderRadius: "50%",
+              animation: "spin 1s linear infinite",
+            }}
+          />
+          <style jsx global>{`
+            @keyframes spin { to { transform: rotate(360deg); } }
+          `}</style>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {channels.map((channel) => (
+            <SlackChannelCard
+              key={channel.name}
+              name={channel.name}
+              channelId={channel.channelId}
+              messages={channel.messages}
+              error={channel.error}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/costs/page.tsx
+++ b/src/app/(dashboard)/costs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { DollarSign, TrendingUp, TrendingDown, AlertTriangle, Calendar, PieChart } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { DollarSign, TrendingUp, TrendingDown, AlertTriangle } from "lucide-react";
 import { LineChart, Line, BarChart, Bar, PieChart as RePieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 
 interface CostData {
@@ -30,13 +30,7 @@ export default function CostsPage() {
   const [loading, setLoading] = useState(true);
   const [timeframe, setTimeframe] = useState<"7d" | "30d" | "90d">("30d");
 
-  useEffect(() => {
-    fetchCostData();
-    const interval = setInterval(fetchCostData, 60000); // Update every minute
-    return () => clearInterval(interval);
-  }, [timeframe]);
-
-  const fetchCostData = async () => {
+  const fetchCostData = useCallback(async () => {
     try {
       const res = await fetch(`/api/costs?timeframe=${timeframe}`);
       if (res.ok) {
@@ -48,7 +42,13 @@ export default function CostsPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [timeframe]);
+
+  useEffect(() => {
+    fetchCostData();
+    const interval = setInterval(fetchCostData, 60000);
+    return () => clearInterval(interval);
+  }, [fetchCostData]);
 
   if (loading) {
     return (

--- a/src/app/(dashboard)/files/page.tsx
+++ b/src/app/(dashboard)/files/page.tsx
@@ -55,7 +55,7 @@ export default function FilesPage() {
           File Browser
         </h1>
         <p style={{ fontFamily: "var(--font-body)", fontSize: "13px", color: "var(--text-secondary)" }}>
-          Navega por los workspaces y archivos de los agentes
+          Browse agent workspaces and files
         </p>
       </div>
 
@@ -181,7 +181,7 @@ export default function FilesPage() {
                 <div style={{ display: "flex", gap: "4px", flexShrink: 0 }}>
                   <button
                     onClick={() => setViewMode("list")}
-                    title="Vista lista"
+                    title="List view"
                     style={{
                       padding: "5px 7px",
                       borderRadius: "6px",
@@ -199,7 +199,7 @@ export default function FilesPage() {
                   </button>
                   <button
                     onClick={() => setViewMode("grid")}
-                    title="Vista iconos"
+                    title="Icon view"
                     style={{
                       padding: "5px 7px",
                       borderRadius: "6px",
@@ -239,7 +239,7 @@ export default function FilesPage() {
                 fontSize: "14px",
               }}
             >
-              Selecciona un workspace para explorar sus archivos
+              Select a workspace to browse its files
             </div>
           )}
         </main>

--- a/src/app/(dashboard)/files/page.tsx
+++ b/src/app/(dashboard)/files/page.tsx
@@ -15,6 +15,7 @@ interface Workspace {
 
 export default function FilesPage() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [workspacesLoading, setWorkspacesLoading] = useState(true);
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null);
   const [currentPath, setCurrentPath] = useState("");
   const [viewMode, setViewMode] = useState<"list" | "grid">("list");
@@ -23,12 +24,12 @@ export default function FilesPage() {
     fetch("/api/files/workspaces")
       .then((res) => res.json())
       .then((data) => {
-        setWorkspaces(data.workspaces || []);
-        if (data.workspaces.length > 0) {
-          setSelectedWorkspace(data.workspaces[0].id);
-        }
+        const ws: Workspace[] = data.workspaces || [];
+        setWorkspaces(ws);
+        if (ws.length > 0) setSelectedWorkspace(ws[0].id);
       })
-      .catch(() => setWorkspaces([]));
+      .catch(() => setWorkspaces([]))
+      .finally(() => setWorkspacesLoading(false));
   }, []);
 
   const handleWorkspaceSelect = (workspaceId: string) => {
@@ -92,7 +93,13 @@ export default function FilesPage() {
             Workspaces
           </p>
 
-          {workspaces.map((workspace) => {
+          {workspacesLoading ? (
+            <div style={{ padding: "12px 16px", fontSize: "12px", color: "var(--text-muted)" }}>Loading...</div>
+          ) : workspaces.length === 0 ? (
+            <div style={{ padding: "12px 16px", fontSize: "12px", color: "var(--text-muted)" }}>
+              No workspaces configured. Set OPENCLAW_WORKSPACE in your environment.
+            </div>
+          ) : workspaces.map((workspace) => {
             const isSelected = selectedWorkspace === workspace.id;
             return (
               <button
@@ -112,7 +119,7 @@ export default function FilesPage() {
                   transition: "all 120ms ease",
                 }}
                 onMouseEnter={(e) => {
-                  if (!isSelected) e.currentTarget.style.background = "var(--surface-hover, rgba(255,255,255,0.05))";
+                  if (!isSelected) e.currentTarget.style.background = "var(--surface-hover, rgba(255,255,255,0.08))";
                 }}
                 onMouseLeave={(e) => {
                   if (!isSelected) e.currentTarget.style.background = "transparent";
@@ -124,7 +131,7 @@ export default function FilesPage() {
                     style={{
                       fontFamily: "var(--font-heading)",
                       fontSize: "13px",
-                      fontWeight: isSelected ? 600 : 400,
+                      fontWeight: isSelected ? 600 : 500,
                       color: isSelected ? "var(--accent)" : "var(--text-primary)",
                       whiteSpace: "nowrap",
                       overflow: "hidden",

--- a/src/app/(dashboard)/git/page.tsx
+++ b/src/app/(dashboard)/git/page.tsx
@@ -5,7 +5,6 @@ import {
   GitBranch, GitCommit, ArrowUp, ArrowDown, RefreshCw,
   AlertCircle, CheckCircle, Terminal, X, Loader2, FolderGit2,
 } from "lucide-react";
-import { format } from "date-fns";
 
 interface CommitInfo {
   hash: string;

--- a/src/app/(dashboard)/jira/page.tsx
+++ b/src/app/(dashboard)/jira/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Kanban, RefreshCw, ExternalLink, AlertCircle } from "lucide-react";
+import { Kanban, RefreshCw, ExternalLink, AlertCircle, Send } from "lucide-react";
 import { JIRA_COLUMNS, priorityIcon, type JiraIssue, type JiraStatus } from "@/lib/jira";
 
 const COLUMN_COLORS: Record<JiraStatus, string> = {
@@ -18,8 +18,10 @@ function IssueCard({
   onStarted: (key: string) => void;
 }) {
   const [starting, setStarting] = useState(false);
+  const [dispatching, setDispatching] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const isStartable = issue.status === "To Do";
+  const isDispatchable = issue.status !== "Done";
 
   const handleStart = async () => {
     setStarting(true);
@@ -41,6 +43,25 @@ function IssueCard({
     } finally {
       setStarting(false);
       setTimeout(() => setFeedback(null), 4000);
+    }
+  };
+
+  const handleDispatch = async () => {
+    setDispatching(true);
+    const message = `Work on ${issue.key}: ${issue.summary}\n\nJira: ${issue.url}\n\nCurrent status: ${issue.status}. Please pick this up, implement the changes needed, and move the issue to Done when complete.`;
+    try {
+      const res = await fetch("/api/agents/dispatch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentSlug: "main", message }),
+      });
+      const data = await res.json();
+      setFeedback(data.ok ? "Dispatched to Max ✓" : `Error: ${data.error}`);
+    } catch {
+      setFeedback("Dispatch failed");
+    } finally {
+      setDispatching(false);
+      setTimeout(() => setFeedback(null), 5000);
     }
   };
 
@@ -100,21 +121,40 @@ function IssueCard({
             {feedback}
           </span>
         )}
-        {isStartable && !feedback && (
-          <button
-            onClick={handleStart}
-            disabled={starting}
-            className="ml-auto text-xs px-2 py-0.5 rounded transition-all"
-            style={{
-              border: "1px solid var(--border)",
-              color: "var(--text-secondary)",
-              backgroundColor: "transparent",
-              cursor: starting ? "wait" : "pointer",
-            }}
-          >
-            {starting ? "…" : "▶ Start"}
-          </button>
-        )}
+        <div className="ml-auto flex items-center gap-1">
+          {isStartable && !feedback && (
+            <button
+              onClick={handleStart}
+              disabled={starting}
+              className="text-xs px-2 py-0.5 rounded transition-all"
+              style={{
+                border: "1px solid var(--border)",
+                color: "var(--text-secondary)",
+                backgroundColor: "transparent",
+                cursor: starting ? "wait" : "pointer",
+              }}
+            >
+              {starting ? "…" : "▶ Start"}
+            </button>
+          )}
+          {isDispatchable && !feedback && (
+            <button
+              onClick={handleDispatch}
+              disabled={dispatching}
+              title="Send to Max"
+              className="flex items-center gap-1 text-xs px-2 py-0.5 rounded transition-all"
+              style={{
+                border: "1px solid var(--border)",
+                color: "var(--accent)",
+                backgroundColor: "color-mix(in srgb, var(--accent) 8%, transparent)",
+                cursor: dispatching ? "wait" : "pointer",
+              }}
+            >
+              <Send className="w-3 h-3" />
+              {dispatching ? "…" : "Max"}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -236,7 +276,7 @@ export default function JiraPage() {
         </div>
         <div className="flex items-center gap-2">
           <a
-            href={`${process.env.NEXT_PUBLIC_JIRA_BASE_URL ?? "https://neuralops.atlassian.net"}/jira/software/projects/NEURALOPS/boards`}
+            href="https://neuralops.atlassian.net/jira/software/projects/NEURALOPS/boards"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1.5 text-sm"

--- a/src/app/(dashboard)/jira/page.tsx
+++ b/src/app/(dashboard)/jira/page.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Kanban, RefreshCw, ExternalLink, AlertCircle } from "lucide-react";
+import { JIRA_COLUMNS, priorityIcon, type JiraIssue, type JiraStatus } from "@/lib/jira";
+
+const COLUMN_COLORS: Record<JiraStatus, string> = {
+  "To Do": "#6b7280",
+  "In Progress": "#3b82f6",
+  "Done": "#22c55e",
+};
+
+function IssueCard({
+  issue,
+  onStarted,
+}: {
+  issue: JiraIssue;
+  onStarted: (key: string) => void;
+}) {
+  const [starting, setStarting] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const isStartable = issue.status === "To Do";
+
+  const handleStart = async () => {
+    setStarting(true);
+    try {
+      const res = await fetch(`/api/jira/${issue.key}/transition`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transitionName: "In Progress" }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setFeedback(`Error: ${data.error}`);
+      } else {
+        setFeedback("Started ✓");
+        onStarted(issue.key);
+      }
+    } catch {
+      setFeedback("Failed");
+    } finally {
+      setStarting(false);
+      setTimeout(() => setFeedback(null), 4000);
+    }
+  };
+
+  return (
+    <div
+      className="rounded-lg p-3 space-y-2 transition-all hover:scale-[1.01]"
+      style={{
+        backgroundColor: "var(--card-elevated)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <a
+          href={issue.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono text-xs hover:underline"
+          style={{ color: "var(--text-muted)" }}
+        >
+          {issue.key}
+        </a>
+        <span className="text-xs flex-shrink-0">{priorityIcon(issue.priority)}</span>
+      </div>
+
+      <a
+        href={issue.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block text-xs leading-snug hover:underline"
+        style={{ color: "var(--text-secondary)" }}
+      >
+        {issue.summary}
+      </a>
+
+      <div className="flex items-center justify-between gap-2">
+        {issue.assignee && (
+          <div className="flex items-center gap-1.5">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={issue.assignee.avatarUrl}
+              alt={issue.assignee.displayName}
+              className="w-4 h-4 rounded-full"
+            />
+            <span
+              className="text-xs truncate max-w-[80px]"
+              style={{ color: "var(--text-muted)" }}
+            >
+              {issue.assignee.displayName}
+            </span>
+          </div>
+        )}
+        {feedback && (
+          <span
+            className="text-xs font-mono ml-auto"
+            style={{ color: "var(--text-muted)" }}
+          >
+            {feedback}
+          </span>
+        )}
+        {isStartable && !feedback && (
+          <button
+            onClick={handleStart}
+            disabled={starting}
+            className="ml-auto text-xs px-2 py-0.5 rounded transition-all"
+            style={{
+              border: "1px solid var(--border)",
+              color: "var(--text-secondary)",
+              backgroundColor: "transparent",
+              cursor: starting ? "wait" : "pointer",
+            }}
+          >
+            {starting ? "…" : "▶ Start"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function KanbanColumn({
+  status,
+  issues,
+  onStarted,
+}: {
+  status: JiraStatus;
+  issues: JiraIssue[];
+  onStarted: (key: string) => void;
+}) {
+  const color = COLUMN_COLORS[status];
+  return (
+    <div className="flex-1 min-w-[220px] space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className="w-2 h-2 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "var(--text-muted)" }}
+          >
+            {status}
+          </h2>
+        </div>
+        <span
+          className="font-mono text-xs px-2 py-0.5 rounded"
+          style={{
+            backgroundColor: "var(--card-elevated)",
+            border: "1px solid var(--border)",
+            color: "var(--text-muted)",
+          }}
+        >
+          {issues.length}
+        </span>
+      </div>
+      <div className="space-y-2">
+        {issues.length === 0 && (
+          <p className="text-xs italic" style={{ color: "var(--text-muted)" }}>
+            —
+          </p>
+        )}
+        {issues.map((issue) => (
+          <IssueCard key={issue.id} issue={issue} onStarted={onStarted} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function JiraPage() {
+  const [issues, setIssues] = useState<JiraIssue[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const fetchIssues = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await fetch("/api/jira/issues");
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+      setIssues(data.issues ?? []);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load issues");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchIssues();
+    const interval = setInterval(fetchIssues, 60_000);
+    return () => clearInterval(interval);
+  }, [fetchIssues]);
+
+  const handleStarted = (key: string) => {
+    setIssues((prev) =>
+      prev.map((i) => (i.key === key ? { ...i, status: "In Progress" } : i)),
+    );
+  };
+
+  const byStatus = Object.fromEntries(
+    JIRA_COLUMNS.map((col) => [col, issues.filter((i) => i.status === col)]),
+  ) as Record<JiraStatus, JiraIssue[]>;
+
+  const openCount = issues.filter((i) => i.status !== "Done").length;
+
+  return (
+    <div className="p-4 md:p-8">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1
+            className="text-3xl font-bold mb-1"
+            style={{
+              fontFamily: "var(--font-heading)",
+              color: "var(--text-primary)",
+              letterSpacing: "-1.5px",
+            }}
+          >
+            <Kanban className="inline-block w-8 h-8 mr-2 mb-1" />
+            NEURALOPS Board
+          </h1>
+          <p style={{ color: "var(--text-secondary)", fontSize: "14px" }}>
+            {openCount} open issues
+            {lastUpdated && (
+              <span style={{ color: "var(--text-muted)", marginLeft: "8px" }}>
+                · Updated {lastUpdated.toLocaleTimeString()}
+              </span>
+            )}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <a
+            href={`${process.env.NEXT_PUBLIC_JIRA_BASE_URL ?? "https://neuralops.atlassian.net"}/jira/software/projects/NEURALOPS/boards`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-sm"
+            style={{ color: "var(--text-muted)" }}
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            Open in Jira
+          </a>
+          <button
+            onClick={() => { setLoading(true); fetchIssues(); }}
+            className="flex items-center gap-2"
+            style={{
+              padding: "0.5rem 1rem",
+              backgroundColor: "var(--card)",
+              color: "var(--text-primary)",
+              borderRadius: "0.5rem",
+              border: "1px solid var(--border)",
+              cursor: "pointer",
+              fontWeight: 500,
+            }}
+          >
+            <RefreshCw className="w-4 h-4" />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          className="mb-4 flex items-center gap-3 p-4 rounded-xl"
+          style={{
+            backgroundColor: "color-mix(in srgb, var(--negative) 10%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--negative) 30%, transparent)",
+          }}
+        >
+          <AlertCircle className="w-5 h-5" style={{ color: "var(--negative)" }} />
+          <span style={{ color: "var(--negative)" }}>{error}</span>
+        </div>
+      )}
+
+      {/* Board */}
+      {loading && issues.length === 0 ? (
+        <div className="flex items-center justify-center py-16">
+          <div
+            style={{
+              width: "2rem",
+              height: "2rem",
+              border: "2px solid var(--accent)",
+              borderTopColor: "transparent",
+              borderRadius: "50%",
+              animation: "spin 1s linear infinite",
+            }}
+          />
+          <style jsx global>{`
+            @keyframes spin { to { transform: rotate(360deg); } }
+          `}</style>
+        </div>
+      ) : (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {JIRA_COLUMNS.map((col) => (
+            <KanbanColumn
+              key={col}
+              status={col}
+              issues={byStatus[col] ?? []}
+              onStarted={handleStarted}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/logs/page.tsx
+++ b/src/app/(dashboard)/logs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Terminal, Play, Square, Trash2, Download, Circle, Server } from "lucide-react";
+import { Terminal, Play, Square, Trash2, Download, Circle } from "lucide-react";
 
 interface LogLine {
   line: string;

--- a/src/app/(dashboard)/memory/page.tsx
+++ b/src/app/(dashboard)/memory/page.tsx
@@ -138,7 +138,7 @@ export default function MemoryPage() {
           Memory Browser
         </h1>
         <p style={{ fontFamily: "var(--font-body)", fontSize: "13px", color: "var(--text-secondary)" }}>
-          Ver y editar archivos de memoria de los agentes
+          View and edit agent memory files
         </p>
       </div>
 
@@ -420,7 +420,7 @@ export default function MemoryPage() {
                     >
                       <div style={{ textAlign: "center" }}>
                         <Brain style={{ width: "64px", height: "64px", margin: "0 auto 16px", opacity: 0.3 }} />
-                        <p style={{ fontSize: "14px" }}>Selecciona un archivo para ver o editar</p>
+                        <p style={{ fontSize: "14px" }}>Select a file to view or edit</p>
                       </div>
                     </div>
                   )}
@@ -438,7 +438,7 @@ export default function MemoryPage() {
                 fontSize: "14px",
               }}
             >
-              Selecciona un workspace
+              Select a workspace
             </div>
           )}
         </main>

--- a/src/app/(dashboard)/memory/page.tsx
+++ b/src/app/(dashboard)/memory/page.tsx
@@ -18,6 +18,7 @@ interface Workspace {
 
 export default function MemoryPage() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [workspacesLoading, setWorkspacesLoading] = useState(true);
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null);
   const [files, setFiles] = useState<FileNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -34,12 +35,12 @@ export default function MemoryPage() {
     fetch("/api/files/workspaces")
       .then((res) => res.json())
       .then((data) => {
-        setWorkspaces(data.workspaces || []);
-        if (data.workspaces.length > 0) {
-          setSelectedWorkspace(data.workspaces[0].id);
-        }
+        const ws: Workspace[] = data.workspaces || [];
+        setWorkspaces(ws);
+        if (ws.length > 0) setSelectedWorkspace(ws[0].id);
       })
-      .catch(() => setWorkspaces([]));
+      .catch(() => setWorkspaces([]))
+      .finally(() => setWorkspacesLoading(false));
   }, []);
 
   const loadFileTree = useCallback(async (workspace: string) => {
@@ -175,7 +176,13 @@ export default function MemoryPage() {
             Workspaces
           </p>
 
-          {workspaces.map((workspace) => {
+          {workspacesLoading ? (
+            <div style={{ padding: "12px 16px", fontSize: "12px", color: "var(--text-muted)" }}>Loading...</div>
+          ) : workspaces.length === 0 ? (
+            <div style={{ padding: "12px 16px", fontSize: "12px", color: "var(--text-muted)" }}>
+              No workspaces configured. Set OPENCLAW_WORKSPACE in your environment.
+            </div>
+          ) : workspaces.map((workspace) => {
             const isSelected = selectedWorkspace === workspace.id;
             return (
               <button
@@ -195,7 +202,7 @@ export default function MemoryPage() {
                   transition: "all 120ms ease",
                 }}
                 onMouseEnter={(e) => {
-                  if (!isSelected) e.currentTarget.style.background = "var(--surface-hover, rgba(255,255,255,0.05))";
+                  if (!isSelected) e.currentTarget.style.background = "var(--surface-hover, rgba(255,255,255,0.08))";
                 }}
                 onMouseLeave={(e) => {
                   if (!isSelected) e.currentTarget.style.background = "transparent";
@@ -207,7 +214,7 @@ export default function MemoryPage() {
                     style={{
                       fontFamily: "var(--font-heading)",
                       fontSize: "13px",
-                      fontWeight: isSelected ? 600 : 400,
+                      fontWeight: isSelected ? 600 : 500,
                       color: isSelected ? "var(--accent)" : "var(--text-primary)",
                       whiteSpace: "nowrap",
                       overflow: "hidden",

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -77,7 +77,7 @@ export default function DashboardPage() {
           🦞 Mission Control
         </h1>
         <p style={{ color: 'var(--text-secondary)', fontSize: '14px' }}>
-          Overview of Tenacitas agent activity
+          Overview of NeuralOps agent activity
         </p>
       </div>
 

--- a/src/app/(dashboard)/sessions/page.tsx
+++ b/src/app/(dashboard)/sessions/page.tsx
@@ -89,7 +89,6 @@ function MessageBubble({ msg }: { msg: Message }) {
   const isUser = msg.type === "user";
   const isTool = msg.type === "tool_use";
   const isResult = msg.type === "tool_result";
-  const isAssistant = msg.type === "assistant";
 
   if (isTool) {
     return (

--- a/src/app/(dashboard)/system/page.tsx
+++ b/src/app/(dashboard)/system/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Cpu, HardDrive, MemoryStick, Activity, Network, Server, ShieldCheck, RotateCw, Wifi, Monitor, Play, Square, X, Loader2, Terminal, ArrowDown, ArrowUp } from "lucide-react";
+import { Cpu, HardDrive, MemoryStick, Network, Server, ShieldCheck, RotateCw, Wifi, Monitor, Play, Square, X, Loader2, Terminal, ArrowDown, ArrowUp } from "lucide-react";
 
 interface SystemdService {
   name: string;

--- a/src/app/(dashboard)/system/page.tsx
+++ b/src/app/(dashboard)/system/page.tsx
@@ -29,10 +29,20 @@ interface FirewallRule {
   comment: string;
 }
 
+interface DiskEntry {
+  mountpoint: string;
+  total: number;
+  used: number;
+  free: number;
+  percent: number;
+}
+
 interface SystemData {
   cpu: { usage: number; cores: number[]; loadAvg: number[] };
   ram: { total: number; used: number; free: number; cached: number };
+  swap?: { total: number; used: number; free: number; percent: number };
   disk: { total: number; used: number; free: number; percent: number };
+  disks?: DiskEntry[];
   network: { rx: number; tx: number };
   systemd: SystemdService[];
   tailscale: { active: boolean; ip: string; devices: TailscaleDevice[] };
@@ -248,7 +258,7 @@ export default function SystemMonitorPage() {
             </div>
           </div>
 
-          {/* RAM */}
+          {/* RAM + Swap */}
           <div className="p-6 rounded-xl" style={{ backgroundColor: "var(--card)", border: "1px solid var(--border)" }}>
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-3">
@@ -262,29 +272,52 @@ export default function SystemMonitorPage() {
               </div>
               <span className="text-2xl font-bold" style={{ color: ramColor }}>{ramPercent.toFixed(0)}%</span>
             </div>
-            <div className="h-2 rounded-full overflow-hidden" style={{ backgroundColor: "var(--card-elevated)" }}>
+            <div className="h-2 rounded-full overflow-hidden mb-4" style={{ backgroundColor: "var(--card-elevated)" }}>
               <div className="h-full transition-all duration-500" style={{ width: `${ramPercent}%`, backgroundColor: ramColor }} />
             </div>
+            {systemData.swap && systemData.swap.total > 0 && (() => {
+              const swapColor = systemData.swap!.percent < 60 ? "var(--success)" : systemData.swap!.percent < 85 ? "var(--warning)" : "var(--error)";
+              return (
+                <>
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-sm font-medium" style={{ color: "var(--text-secondary)" }}>
+                      Swap — {systemData.swap!.used.toFixed(1)}GB / {systemData.swap!.total.toFixed(1)}GB
+                    </span>
+                    <span className="text-sm font-bold" style={{ color: swapColor }}>{systemData.swap!.percent.toFixed(0)}%</span>
+                  </div>
+                  <div className="h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: "var(--card-elevated)" }}>
+                    <div className="h-full transition-all duration-500" style={{ width: `${systemData.swap!.percent}%`, backgroundColor: swapColor }} />
+                  </div>
+                </>
+              );
+            })()}
           </div>
 
-          {/* Disk */}
-          <div className="p-6 rounded-xl" style={{ backgroundColor: "var(--card)", border: "1px solid var(--border)" }}>
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 rounded-lg" style={{ backgroundColor: "var(--card-elevated)" }}>
-                  <HardDrive className="w-5 h-5" style={{ color: diskColor }} />
+          {/* Disks */}
+          {(systemData.disks && systemData.disks.length > 0 ? systemData.disks : [{ mountpoint: '/', ...systemData.disk }]).map((disk) => {
+            const dc = disk.percent < 60 ? "var(--success)" : disk.percent < 85 ? "var(--warning)" : "var(--error)";
+            return (
+              <div key={disk.mountpoint} className="p-6 rounded-xl" style={{ backgroundColor: "var(--card)", border: "1px solid var(--border)" }}>
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 rounded-lg" style={{ backgroundColor: "var(--card-elevated)" }}>
+                      <HardDrive className="w-5 h-5" style={{ color: dc }} />
+                    </div>
+                    <div>
+                      <h3 className="font-semibold" style={{ color: "var(--text-primary)" }}>
+                        Disk <span className="font-mono text-xs" style={{ color: "var(--text-muted)" }}>{disk.mountpoint}</span>
+                      </h3>
+                      <p className="text-sm" style={{ color: "var(--text-secondary)" }}>{disk.used}GB / {disk.total}GB</p>
+                    </div>
+                  </div>
+                  <span className="text-2xl font-bold" style={{ color: dc }}>{disk.percent.toFixed(0)}%</span>
                 </div>
-                <div>
-                  <h3 className="font-semibold" style={{ color: "var(--text-primary)" }}>Disk</h3>
-                  <p className="text-sm" style={{ color: "var(--text-secondary)" }}>{systemData.disk.used.toFixed(1)}GB / {systemData.disk.total.toFixed(1)}GB</p>
+                <div className="h-2 rounded-full overflow-hidden" style={{ backgroundColor: "var(--card-elevated)" }}>
+                  <div className="h-full transition-all duration-500" style={{ width: `${disk.percent}%`, backgroundColor: dc }} />
                 </div>
               </div>
-              <span className="text-2xl font-bold" style={{ color: diskColor }}>{systemData.disk.percent.toFixed(0)}%</span>
-            </div>
-            <div className="h-2 rounded-full overflow-hidden" style={{ backgroundColor: "var(--card-elevated)" }}>
-              <div className="h-full transition-all duration-500" style={{ width: `${systemData.disk.percent}%`, backgroundColor: diskColor }} />
-            </div>
-          </div>
+            );
+          })}
 
           {/* Network */}
           <div className="p-6 rounded-xl" style={{ backgroundColor: "var(--card)", border: "1px solid var(--border)" }}>

--- a/src/app/(dashboard)/system/page.tsx
+++ b/src/app/(dashboard)/system/page.tsx
@@ -173,7 +173,6 @@ export default function SystemMonitorPage() {
   const cpuColor = systemData.cpu.usage < 60 ? "var(--success)" : systemData.cpu.usage < 85 ? "var(--warning)" : "var(--error)";
   const ramPercent = (systemData.ram.used / systemData.ram.total) * 100;
   const ramColor = ramPercent < 60 ? "var(--success)" : ramPercent < 85 ? "var(--warning)" : "var(--error)";
-  const diskColor = systemData.disk.percent < 60 ? "var(--success)" : systemData.disk.percent < 85 ? "var(--warning)" : "var(--error)";
 
   const activeServices = systemData.systemd.filter((s) => s.status === "active").length;
 

--- a/src/app/(dashboard)/terminal/page.tsx
+++ b/src/app/(dashboard)/terminal/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Terminal, Send, Trash2, Copy, ChevronRight } from "lucide-react";
+import { Terminal, Send, Trash2, Copy } from "lucide-react";
 
 interface HistoryEntry {
   command: string;

--- a/src/app/(dashboard)/terminal/page.tsx
+++ b/src/app/(dashboard)/terminal/page.tsx
@@ -188,7 +188,7 @@ export default function TerminalPage() {
             <div key={i} style={{ marginBottom: "1rem" }}>
               {/* Command prompt */}
               <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.25rem" }}>
-                <span style={{ color: "#4ade80" }}>tenacitas@srv</span>
+                <span style={{ color: "#4ade80" }}>neuralops@srv</span>
                 <span style={{ color: "#8b949e" }}>:</span>
                 <span style={{ color: "#60a5fa" }}>~</span>
                 <span style={{ color: "#c9d1d9" }}>$ {entry.command}</span>

--- a/src/app/(dashboard)/workflows/page.tsx
+++ b/src/app/(dashboard)/workflows/page.tsx
@@ -15,6 +15,24 @@ interface Workflow {
 
 const WORKFLOWS: Workflow[] = [
   {
+    id: "jira-auto-dispatch",
+    emoji: "🎯",
+    name: "Jira Auto-Dispatch",
+    description: "Monitors the NEURALOPS kanban board for To Do items and automatically dispatches them to OpenClaw agents, transitions them to In Progress, and sends Slack + in-app notifications.",
+    schedule: "On webhook event (Jira Automation) or manual via POST /api/jira/auto-dispatch",
+    trigger: "demand",
+    status: "active",
+    steps: [
+      "Jira Automation triggers /api/jira/webhook when an issue is created or moved to To Do",
+      "Webhook fetches the full issue from the Jira API and validates status",
+      "Calls /api/jira/auto-dispatch to dispatch the issue to the main OpenClaw agent",
+      "Transitions the issue to In Progress in Jira",
+      "Posts a comment on the Jira issue confirming the dispatch",
+      "Sends a Slack notification to #dev with issue title and link",
+      "Creates a TenacitOS in-app notification",
+    ],
+  },
+  {
     id: "social-radar",
     emoji: "🔭",
     name: "Social Radar",

--- a/src/app/(dashboard)/workflows/page.tsx
+++ b/src/app/(dashboard)/workflows/page.tsx
@@ -36,161 +36,161 @@ const WORKFLOWS: Workflow[] = [
     id: "social-radar",
     emoji: "🔭",
     name: "Social Radar",
-    description: "Monitoriza menciones, oportunidades de colaboración y conversaciones relevantes en redes sociales y foros.",
-    schedule: "9:30h y 17:30h (cada día)",
+    description: "Monitors mentions, collaboration opportunities, and relevant conversations on social media and forums.",
+    schedule: "9:30 and 17:30 (daily)",
     trigger: "cron",
     status: "active",
     steps: [
-      `Busca menciones de ${BRANDING.twitterHandle} en Twitter/X, LinkedIn e Instagram`,
-      "Revisa hilos de Reddit en r/webdev, r/javascript, r/learnprogramming",
-      `Detecta oportunidades de colaboración y collabs entrantes (${BRANDING.ownerCollabEmail})`,
-      "Monitoriza aprendiendo.dev en conversaciones y menciones",
-      "Envía resumen por Telegram si hay algo relevante",
+      `Search mentions of ${BRANDING.twitterHandle} on Twitter/X, LinkedIn and Instagram`,
+      "Review Reddit threads in r/webdev, r/javascript, r/learnprogramming",
+      `Detect collaboration opportunities and inbound collabs (${BRANDING.ownerCollabEmail})`,
+      "Monitor neuralops.ca in conversations and mentions",
+      "Send Telegram summary if anything relevant is found",
     ],
   },
   {
-    id: "noticias-ia",
+    id: "ai-news",
     emoji: "📰",
-    name: "Noticias IA y Web",
-    description: "Resume las noticias más relevantes de IA y desarrollo web del timeline de Twitter para arrancar el día informado.",
-    schedule: "7:45h (cada día)",
+    name: "AI & Web News",
+    description: "Summarizes the most relevant AI and web development news from the Twitter timeline to start the day informed.",
+    schedule: "7:45 (daily)",
     trigger: "cron",
     status: "active",
     steps: [
-      "Lee el timeline de Twitter/X via bird CLI",
-      "Filtra noticias de IA, web dev, arquitectura y herramientas dev",
-      "Selecciona 5-7 noticias más relevantes para el nicho de Carlos",
-      "Genera resumen estructurado con enlace y contexto",
-      "Envía digest por Telegram",
+      "Read the Twitter/X timeline via bird CLI",
+      "Filter AI, web dev, architecture and dev tools news",
+      `Select 5-7 most relevant news items for ${BRANDING.ownerUsername}'s niche`,
+      "Generate structured summary with links and context",
+      "Send digest via Telegram",
     ],
   },
   {
     id: "trend-monitor",
     emoji: "🔥",
     name: "Trend Monitor",
-    description: "Radar de tendencias urgentes en el nicho tech. Detecta temas virales antes de que exploten para aprovechar la ola de contenido.",
-    schedule: "7h, 10h, 15h y 20h (cada día)",
+    description: "Urgent trends radar in the tech niche. Detects viral topics before they explode to ride the content wave.",
+    schedule: "7h, 10h, 15h and 20h (daily)",
     trigger: "cron",
     status: "active",
     steps: [
-      "Monitoriza trending topics en Twitter/X relacionados con tech y programación",
-      "Busca en Hacker News, dev.to y GitHub Trending",
-      "Evalúa si el trend es relevante para el canal de Carlos",
-      "Si detecta algo urgente, notifica inmediatamente con contexto",
-      "Sugiere ángulo de contenido si el trend tiene potencial",
+      "Monitor trending topics on Twitter/X related to tech and programming",
+      "Search Hacker News, dev.to and GitHub Trending",
+      `Evaluate if the trend is relevant for ${BRANDING.ownerUsername}'s channel`,
+      "If something urgent is detected, notify immediately with context",
+      "Suggest content angle if the trend has potential",
     ],
   },
   {
     id: "daily-linkedin",
     emoji: "📊",
     name: "Daily LinkedIn Brief",
-    description: "Genera el post de LinkedIn del día basado en las noticias más relevantes de Hacker News, dev.to y la web tech.",
-    schedule: "9h (cada día)",
+    description: "Generates the day's LinkedIn post based on the most relevant news from Hacker News, dev.to and the tech web.",
+    schedule: "9h (daily)",
     trigger: "cron",
     status: "active",
     steps: [
-      "Recopila top posts de Hacker News (front page tech/dev)",
-      "Revisa trending en dev.to y artículos destacados",
-      "Selecciona tema con mayor potencial de engagement para la audiencia de Carlos",
-      "Redacta post de LinkedIn en la voz de Carlos (profesional-cercano, sin emojis ni hashtags)",
-      "Envía borrador por Telegram para revisión y publicación",
+      "Gather top Hacker News posts (front page tech/dev)",
+      "Review dev.to trending and featured articles",
+      `Select topic with highest engagement potential for ${BRANDING.ownerUsername}'s audience`,
+      `Draft LinkedIn post in ${BRANDING.ownerUsername}'s voice (professional-approachable, no emoji or hashtags)`,
+      "Send draft via Telegram for review and publishing",
     ],
   },
   {
     id: "newsletter-digest",
     emoji: "📬",
     name: "Newsletter Digest",
-    description: "Digest curado de las newsletters del día. Consolida lo mejor de las suscripciones de Carlos en un resumen accionable.",
-    schedule: "20h (cada día)",
+    description: `Curated digest of the day's newsletters. Consolidates the best from ${BRANDING.ownerUsername}'s subscriptions into an actionable summary.`,
+    schedule: "20h (daily)",
     trigger: "cron",
     status: "active",
     steps: [
-      "Accede a Gmail y busca newsletters recibidas en el día",
-      "Filtra por remitentes relevantes (tech, IA, productividad, inversiones)",
-      "Extrae los puntos clave de cada newsletter",
-      "Genera digest estructurado por categorías",
-      "Envía resumen por Telegram",
+      "Access Gmail and search for newsletters received during the day",
+      "Filter by relevant senders (tech, AI, productivity, investments)",
+      "Extract key points from each newsletter",
+      "Generate structured digest by category",
+      "Send summary via Telegram",
     ],
   },
   {
     id: "email-categorization",
     emoji: "📧",
     name: "Email Categorization",
-    description: "Categoriza y resume los emails del día para que Carlos empiece la jornada sin inbox anxiety.",
-    schedule: "7:45h (cada día)",
+    description: `Categorizes and summarizes the day's emails so ${BRANDING.ownerUsername} can start the day without inbox anxiety.`,
+    schedule: "7:45 (daily)",
     trigger: "cron",
     status: "active",
     steps: [
-      "Accede a Gmail y lee emails no leídos del día",
-      "Categoriza: urgente / colabs / facturas / universidad / newsletters / otros",
-      "Resumen de cada categoría con acción recomendada",
-      "Detecta emails de clientes con facturas pendientes (>90 días)",
-      "Envía resumen estructurado por Telegram",
+      "Access Gmail and read unread emails for the day",
+      "Categorize: urgent / collabs / invoices / university / newsletters / other",
+      "Summarize each category with recommended action",
+      "Detect client emails with outstanding invoices (>90 days)",
+      "Send structured summary via Telegram",
     ],
   },
   {
     id: "weekly-newsletter",
     emoji: "📅",
     name: "Weekly Newsletter",
-    description: "Recapitulación semanal automática de los tweets y posts de LinkedIn para usar como base de la newsletter.",
-    schedule: "Domingos 18h",
+    description: "Automatic weekly recap of tweets and LinkedIn posts to use as the newsletter base.",
+    schedule: "Sundays 18h",
     trigger: "cron",
     status: "active",
     steps: [
-      `Recopila tweets de la semana (${BRANDING.twitterHandle} via bird CLI)`,
-      "Recopila posts publicados en LinkedIn",
-      "Organiza por temas y relevancia",
-      "Genera borrador de recapitulación semanal en tono newsletter",
-      "Envía por Telegram para revisión antes de publicar",
+      `Gather the week's tweets (${BRANDING.twitterHandle} via bird CLI)`,
+      "Gather published LinkedIn posts",
+      "Organize by topic and relevance",
+      "Generate weekly recap draft in newsletter tone",
+      "Send via Telegram for review before publishing",
     ],
   },
   {
     id: "advisory-board",
     emoji: "🏛️",
     name: "Advisory Board",
-    description: "7 asesores IA con personalidades y memorias propias. Consulta a cualquier advisor o convoca al board completo.",
-    schedule: "Bajo demanda",
+    description: "7 AI advisors with distinct personalities and their own memories. Consult any advisor or convene the full board.",
+    schedule: "On demand",
     trigger: "demand",
     status: "active",
     steps: [
-      "Carlos envía /cfo, /cmo, /cto, /legal, /growth, /coach o /producto",
-      "Tenacitas carga el skill advisory-board/SKILL.md",
-      "Lee el archivo de memoria del advisor correspondiente (memory/advisors/)",
-      "Responde en la voz y personalidad del advisor con contexto de Carlos",
-      "Actualiza el archivo de memoria con lo aprendido en la consulta",
-      "/board convoca los 7 advisors en secuencia y compila un board meeting completo",
+      `${BRANDING.ownerUsername} sends /cfo, /cmo, /cto, /legal, /growth, /coach or /product`,
+      "Agent loads the advisory-board/SKILL.md skill",
+      "Reads the corresponding advisor's memory file (memory/advisors/)",
+      `Responds in the advisor's voice and personality with context for ${BRANDING.ownerUsername}`,
+      "Updates the memory file with learnings from the consultation",
+      "/board convenes all 7 advisors in sequence and compiles a full board meeting",
     ],
   },
   {
     id: "git-backup",
     emoji: "🔄",
     name: "Git Backup",
-    description: "Auto-commit y push del workspace cada 4 horas para garantizar que nada se pierde.",
-    schedule: "Cada 4h",
+    description: "Auto-commit and push of the workspace every 4 hours to ensure nothing is lost.",
+    schedule: "Every 4h",
     trigger: "cron",
     status: "active",
     steps: [
-      "Comprueba si hay cambios en el workspace de Tenacitas",
-      "Si hay cambios: git add -A",
-      "Genera mensaje de commit automático con timestamp y resumen de cambios",
-      "git push al repositorio remoto",
-      "Silencioso si no hay cambios — solo notifica si hay error",
+      "Check if there are changes in the workspace",
+      "If there are changes: git add -A",
+      "Generate automatic commit message with timestamp and change summary",
+      "git push to the remote repository",
+      "Silent if no changes — only notifies on error",
     ],
   },
   {
     id: "nightly-evolution",
     emoji: "🌙",
     name: "Nightly Evolution",
-    description: "Sesión autónoma nocturna que implementa mejoras en Mission Control según el ROADMAP o inventa features nuevas útiles.",
-    schedule: "3h (cada noche)",
+    description: "Autonomous nightly session that implements Mission Control improvements from the ROADMAP or invents useful new features.",
+    schedule: "3h (nightly)",
     trigger: "cron",
     status: "active",
     steps: [
-      "Lee ROADMAP.md de Mission Control para seleccionar la siguiente feature",
-      "Si no hay features claras, analiza el estado actual e inventa algo útil",
-      "Implementa la feature completa (código, tests si aplica, UI)",
-      "Verifica que el build de Next.js no falla",
-      "Notifica a Carlos por Telegram con el resumen de lo implementado",
+      "Read Mission Control ROADMAP.md to select the next feature",
+      "If no clear features, analyze current state and invent something useful",
+      "Implement the complete feature (code, tests if applicable, UI)",
+      "Verify the Next.js build does not fail",
+      `Notify ${BRANDING.ownerUsername} via Telegram with a summary of what was implemented`,
     ],
   },
 ];
@@ -212,7 +212,7 @@ function StatusBadge({ status }: { status: "active" | "inactive" }) {
         textTransform: "uppercase",
         letterSpacing: "0.5px",
       }}>
-        {status === "active" ? "Activo" : "Inactivo"}
+        {status === "active" ? "Active" : "Inactive"}
       </span>
     </div>
   );
@@ -234,7 +234,7 @@ function TriggerBadge({ trigger }: { trigger: "cron" | "demand" }) {
       letterSpacing: "0.4px",
       textTransform: "uppercase" as const,
     }}>
-      {trigger === "cron" ? "⏱ Cron" : "⚡ Demanda"}
+      {trigger === "cron" ? "⏱ Cron" : "⚡ On Demand"}
     </div>
   );
 }
@@ -255,7 +255,7 @@ export default function WorkflowsPage() {
           Workflows
         </h1>
         <p style={{ fontFamily: "var(--font-body)", fontSize: "13px", color: "var(--text-secondary)" }}>
-          {WORKFLOWS.filter(w => w.status === "active").length} flujos activos · {WORKFLOWS.filter(w => w.trigger === "cron").length} crons automáticos · {WORKFLOWS.filter(w => w.trigger === "demand").length} bajo demanda
+          {WORKFLOWS.filter(w => w.status === "active").length} active workflows · {WORKFLOWS.filter(w => w.trigger === "cron").length} automatic crons · {WORKFLOWS.filter(w => w.trigger === "demand").length} on demand
         </p>
       </div>
 
@@ -263,8 +263,8 @@ export default function WorkflowsPage() {
       <div style={{ display: "flex", gap: "12px", marginBottom: "32px", flexWrap: "wrap" }}>
         {[
           { label: "Total workflows", value: WORKFLOWS.length, color: "var(--text-primary)" },
-          { label: "Crons activos", value: WORKFLOWS.filter(w => w.trigger === "cron" && w.status === "active").length, color: "#60a5fa" },
-          { label: "Bajo demanda", value: WORKFLOWS.filter(w => w.trigger === "demand").length, color: "var(--accent)" },
+          { label: "Active crons", value: WORKFLOWS.filter(w => w.trigger === "cron" && w.status === "active").length, color: "#60a5fa" },
+          { label: "On demand", value: WORKFLOWS.filter(w => w.trigger === "demand").length, color: "var(--accent)" },
         ].map((stat) => (
           <div key={stat.label} style={{
             padding: "16px 20px",
@@ -381,7 +381,7 @@ export default function WorkflowsPage() {
                 letterSpacing: "0.7px",
                 marginBottom: "8px",
               }}>
-                Pasos
+                Steps
               </div>
               <ol style={{ margin: 0, padding: "0 0 0 16px", display: "flex", flexDirection: "column", gap: "4px" }}>
                 {workflow.steps.map((step, i) => (

--- a/src/app/api/actions/route.ts
+++ b/src/app/api/actions/route.ts
@@ -105,10 +105,10 @@ async function runAction(action: string): Promise<ActionResult> {
 
         // Ping the main site
         try {
-          const { stdout: ping } = await execAsync('curl -s -o /dev/null -w "%{http_code}" --max-time 5 https://tenacitas.cazaustre.dev');
-          results.push(`\n🌐 tenacitas.cazaustre.dev: HTTP ${ping.trim()}`);
+          const { stdout: ping } = await execAsync('curl -s -o /dev/null -w "%{http_code}" --max-time 5 https://neuralops.ca');
+          results.push(`\n🌐 neuralops.ca: HTTP ${ping.trim()}`);
         } catch {
-          results.push('\n🌐 tenacitas.cazaustre.dev: unreachable');
+          results.push('\n🌐 neuralops.ca: unreachable');
         }
 
         output = results.join('\n');

--- a/src/app/api/agents/[id]/status/route.ts
+++ b/src/app/api/agents/[id]/status/route.ts
@@ -54,7 +54,7 @@ export async function GET(
         })
         .sort((a, b) => b.date.localeCompare(a.date))
         .slice(0, 7);
-    } catch (e) {
+    } catch {
       // Memory directory doesn't exist
     }
 

--- a/src/app/api/agents/[id]/status/route.ts
+++ b/src/app/api/agents/[id]/status/route.ts
@@ -4,6 +4,19 @@ import { join } from "path";
 
 export const dynamic = "force-dynamic";
 
+interface RawAgent {
+  id: string;
+  name?: string;
+  workspace: string;
+  model?: { primary?: string };
+  subagents?: { allowAgents?: string[] };
+}
+
+interface AgentSession {
+  id: string;
+  startedAt: string;
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -16,7 +29,7 @@ export async function GET(
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
 
     // Find agent
-    const agent = config.agents.list.find((a: any) => a.id === id);
+    const agent = config.agents.list.find((a: RawAgent) => a.id === id) as RawAgent | undefined;
     if (!agent) {
       return NextResponse.json({ error: "Agent not found" }, { status: 404 });
     }
@@ -47,7 +60,7 @@ export async function GET(
 
     // Get session info (from OpenClaw API if available)
     // For now, we return mock data
-    const sessions: Array<any> = [];
+    const sessions: AgentSession[] = [];
 
     // Get telegram account info
     const telegramAccount = config.channels?.telegram?.accounts?.[id];

--- a/src/app/api/agents/dispatch/route.ts
+++ b/src/app/api/agents/dispatch/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { callGateway, GatewayError } from "@/lib/gateway";
+
+export const dynamic = "force-dynamic";
+
+interface DispatchBody {
+  agentSlug: string;
+  message: string;
+  sessionSuffix?: string;
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as Partial<DispatchBody>;
+  const { agentSlug, message, sessionSuffix = "main" } = body;
+
+  if (!agentSlug || !message) {
+    return NextResponse.json(
+      { error: "agentSlug and message are required" },
+      { status: 400 },
+    );
+  }
+
+  if (!/^[a-z0-9_-]+$/.test(agentSlug)) {
+    return NextResponse.json({ error: "Invalid agentSlug" }, { status: 400 });
+  }
+
+  const sessionKey = `agent:${agentSlug}:${sessionSuffix}`;
+
+  try {
+    await callGateway("sessions.send", {
+      key: sessionKey,
+      message,
+      timeoutMs: 0,
+    });
+    return NextResponse.json({ ok: true, sessionKey });
+  } catch (error) {
+    const msg =
+      error instanceof GatewayError ? error.message : "Dispatch failed";
+    console.error("Dispatch error:", error);
+    return NextResponse.json({ ok: false, error: msg }, { status: 502 });
+  }
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import { readFileSync, statSync } from "fs";
-import { join } from "path";
+import { readFileSync } from "fs";
+import { callGateway, GatewayError, type CronListResult } from "@/lib/gateway";
+import { AGENT_DEFS } from "@/lib/agents-config";
 
 export const dynamic = "force-dynamic";
 
@@ -34,113 +35,107 @@ interface RawAgent {
   ui?: { emoji?: string; color?: string };
 }
 
-// Fallback config used when an agent doesn't define its own ui config in openclaw.json.
-// The main agent reads name/emoji from env vars; all others fall back to generic defaults.
-// Override via each agent's openclaw.json → ui.emoji / ui.color / name fields.
-const DEFAULT_AGENT_CONFIG: Record<string, { emoji: string; color: string; name?: string }> = {
-  main: {
-    emoji: process.env.NEXT_PUBLIC_AGENT_EMOJI || "🤖",
-    color: "#ff6b35",
-    name: process.env.NEXT_PUBLIC_AGENT_NAME || "Mission Control",
-  },
-};
-
-/**
- * Get agent display info (emoji, color, name) from openclaw.json or defaults
- */
-function getAgentDisplayInfo(agentId: string, agentConfig: RawAgent | null): { emoji: string; color: string; name: string } {
-  const configEmoji = agentConfig?.ui?.emoji;
-  const configColor = agentConfig?.ui?.color;
-  const configName = agentConfig?.name;
-
-  // Then try defaults
-  const defaults = DEFAULT_AGENT_CONFIG[agentId];
-
+function getAgentDisplayInfo(
+  agentId: string,
+  agentConfig: RawAgent | null,
+): { emoji: string; color: string; name: string } {
+  const def = AGENT_DEFS.find((a) => a.slug === agentId);
   return {
-    emoji: configEmoji || defaults?.emoji || "🤖",
-    color: configColor || defaults?.color || "#666666",
-    name: configName || defaults?.name || agentId,
+    emoji: agentConfig?.ui?.emoji ?? def?.emoji ?? "🤖",
+    color: agentConfig?.ui?.color ?? def?.color ?? "#666666",
+    name: agentConfig?.name ?? def?.name ?? agentId,
   };
 }
 
 export async function GET() {
   try {
-    // Read openclaw config
-    const configPath = (process.env.OPENCLAW_DIR || "/root/.openclaw") + "/openclaw.json";
+    const configPath =
+      (process.env.OPENCLAW_DIR || "/root/.openclaw") + "/openclaw.json";
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
 
-    // Get agents from config
+    // Fetch live cron state from gateway (best-effort; graceful if gateway is down)
+    let cronJobs: CronListResult["jobs"] = [];
+    try {
+      const result = await callGateway<CronListResult>("cron.list", {});
+      cronJobs = result.jobs ?? [];
+    } catch (err) {
+      if (!(err instanceof GatewayError)) throw err;
+      // Gateway unavailable — agents will show as offline with no last-activity
+    }
+
     const agents: Agent[] = config.agents.list.map((agent: RawAgent) => {
       const agentInfo = getAgentDisplayInfo(agent.id, agent);
+      const def = AGENT_DEFS.find((a) => a.slug === agent.id);
 
-      // Get telegram account info
-      const telegramAccount =
-        config.channels?.telegram?.accounts?.[agent.id];
+      const telegramAccount = config.channels?.telegram?.accounts?.[agent.id];
       const botToken = telegramAccount?.botToken;
 
-      // Check if agent has recent activity
-      const memoryPath = join(agent.workspace, "memory");
-      let lastActivity = undefined;
-      let status: "online" | "offline" = "offline";
+      // Find cron jobs belonging to this agent
+      const agentCrons = cronJobs.filter(
+        (j) =>
+          j.agentId === agent.id ||
+          (def?.cronNames ?? []).includes(j.name),
+      );
 
-      try {
-        const today = new Date().toISOString().split("T")[0];
-        const memoryFile = join(memoryPath, `${today}.md`);
-        const stat = statSync(memoryFile);
-        lastActivity = stat.mtime.toISOString();
-        // Consider online if activity within last 5 minutes
-        status =
-          Date.now() - stat.mtime.getTime() < 5 * 60 * 1000
-            ? "online"
-            : "offline";
-      } catch (e) {
-        // No recent activity
+      // Determine last activity from most recent cron run
+      let lastActivity: string | undefined;
+      let activeSessions = 0;
+      const now = Date.now();
+
+      for (const cron of agentCrons) {
+        if (cron.state.runningAtMs) {
+          activeSessions++;
+        }
+        const ran = cron.state.lastRunAtMs;
+        if (ran) {
+          const iso = new Date(ran).toISOString();
+          if (!lastActivity || ran > new Date(lastActivity).getTime()) {
+            lastActivity = iso;
+          }
+        }
       }
 
-      // Get details of allowed subagents
-      const allowAgents = agent.subagents?.allowAgents || [];
+      // Online = currently running a cron, or ran one in the last 5 minutes
+      const recentRunMs = lastActivity
+        ? now - new Date(lastActivity).getTime()
+        : Infinity;
+      const status: "online" | "offline" =
+        activeSessions > 0 || recentRunMs < 5 * 60 * 1000 ? "online" : "offline";
+
+      const allowAgents = agent.subagents?.allowAgents ?? [];
       const allowAgentsDetails = allowAgents.map((subagentId: string) => {
-        // Find subagent in config
         const subagentConfig = config.agents.list.find(
-          (a: RawAgent) => a.id === subagentId
+          (a: RawAgent) => a.id === subagentId,
         );
-        if (subagentConfig) {
-          const subagentInfo = getAgentDisplayInfo(subagentId, subagentConfig);
-          return {
-            id: subagentId,
-            name: subagentConfig.name || subagentInfo.name,
-            emoji: subagentInfo.emoji,
-            color: subagentInfo.color,
-          };
-        }
-        // Fallback if subagent not found in config
-        const fallbackInfo = getAgentDisplayInfo(subagentId, null);
+        const subagentInfo = getAgentDisplayInfo(
+          subagentId,
+          subagentConfig ?? null,
+        );
         return {
           id: subagentId,
-          name: fallbackInfo.name,
-          emoji: fallbackInfo.emoji,
-          color: fallbackInfo.color,
+          name: subagentConfig?.name ?? subagentInfo.name,
+          emoji: subagentInfo.emoji,
+          color: subagentInfo.color,
         };
       });
 
       return {
         id: agent.id,
-        name: agent.name || agentInfo.name,
+        name: agent.name ?? agentInfo.name,
         emoji: agentInfo.emoji,
         color: agentInfo.color,
-        model:
-          agent.model?.primary || config.agents.defaults.model.primary,
+        model: agent.model?.primary ?? config.agents.defaults?.model?.primary ?? "unknown",
         workspace: agent.workspace,
         dmPolicy:
-          telegramAccount?.dmPolicy ||
-          config.channels?.telegram?.dmPolicy ||
+          telegramAccount?.dmPolicy ??
+          config.channels?.telegram?.dmPolicy ??
           "pairing",
         allowAgents,
         allowAgentsDetails,
         botToken: botToken ? "configured" : undefined,
         status,
         lastActivity,
-        activeSessions: 0, // TODO: get from sessions API
+        activeSessions,
       };
     });
 
@@ -149,7 +144,7 @@ export async function GET() {
     console.error("Error reading agents:", error);
     return NextResponse.json(
       { error: "Failed to load agents" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { readFileSync } from "fs";
+import { readFileSync, statSync } from "fs";
 import { join } from "path";
 
 export const dynamic = "force-dynamic";
@@ -25,6 +25,15 @@ interface Agent {
   activeSessions: number;
 }
 
+interface RawAgent {
+  id: string;
+  name?: string;
+  workspace: string;
+  model?: { primary?: string };
+  subagents?: { allowAgents?: string[] };
+  ui?: { emoji?: string; color?: string };
+}
+
 // Fallback config used when an agent doesn't define its own ui config in openclaw.json.
 // The main agent reads name/emoji from env vars; all others fall back to generic defaults.
 // Override via each agent's openclaw.json → ui.emoji / ui.color / name fields.
@@ -39,8 +48,7 @@ const DEFAULT_AGENT_CONFIG: Record<string, { emoji: string; color: string; name?
 /**
  * Get agent display info (emoji, color, name) from openclaw.json or defaults
  */
-function getAgentDisplayInfo(agentId: string, agentConfig: any): { emoji: string; color: string; name: string } {
-  // First try to get from agent's own config in openclaw.json
+function getAgentDisplayInfo(agentId: string, agentConfig: RawAgent | null): { emoji: string; color: string; name: string } {
   const configEmoji = agentConfig?.ui?.emoji;
   const configColor = agentConfig?.ui?.color;
   const configName = agentConfig?.name;
@@ -62,7 +70,7 @@ export async function GET() {
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
 
     // Get agents from config
-    const agents: Agent[] = config.agents.list.map((agent: any) => {
+    const agents: Agent[] = config.agents.list.map((agent: RawAgent) => {
       const agentInfo = getAgentDisplayInfo(agent.id, agent);
 
       // Get telegram account info
@@ -78,7 +86,7 @@ export async function GET() {
       try {
         const today = new Date().toISOString().split("T")[0];
         const memoryFile = join(memoryPath, `${today}.md`);
-        const stat = require("fs").statSync(memoryFile);
+        const stat = statSync(memoryFile);
         lastActivity = stat.mtime.toISOString();
         // Consider online if activity within last 5 minutes
         status =
@@ -94,7 +102,7 @@ export async function GET() {
       const allowAgentsDetails = allowAgents.map((subagentId: string) => {
         // Find subagent in config
         const subagentConfig = config.agents.list.find(
-          (a: any) => a.id === subagentId
+          (a: RawAgent) => a.id === subagentId
         );
         if (subagentConfig) {
           const subagentInfo = getAgentDisplayInfo(subagentId, subagentConfig);

--- a/src/app/api/auth/avatar/route.ts
+++ b/src/app/api/auth/avatar/route.ts
@@ -9,6 +9,10 @@ const AVATAR_DIR = process.env.OPENCLAW_DIR
 const AVATAR_PATH = path.join(AVATAR_DIR, "avatar.jpg");
 const AVATAR_URL = `/api/media${AVATAR_PATH}`;
 
+function isAuthenticated(request: NextRequest): boolean {
+  return request.cookies.get("mc_auth")?.value === process.env.AUTH_SECRET;
+}
+
 export async function GET() {
   if (!existsSync(AVATAR_PATH)) {
     return NextResponse.json({ url: null });
@@ -17,6 +21,10 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
+  if (!isAuthenticated(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const formData = await request.formData();
     const file = formData.get("file") as File | null;

--- a/src/app/api/auth/avatar/route.ts
+++ b/src/app/api/auth/avatar/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import path from "path";
+
+const AVATAR_DIR = process.env.OPENCLAW_DIR
+  ? path.join(process.env.OPENCLAW_DIR, "media")
+  : "/home/node/.openclaw/media";
+
+const AVATAR_PATH = path.join(AVATAR_DIR, "avatar.jpg");
+const AVATAR_URL = `/api/media${AVATAR_PATH}`;
+
+export async function GET() {
+  if (!existsSync(AVATAR_PATH)) {
+    return NextResponse.json({ url: null });
+  }
+  return NextResponse.json({ url: AVATAR_URL });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+    if (!file) return NextResponse.json({ error: "No file" }, { status: 400 });
+
+    const allowed = ["image/jpeg", "image/png", "image/webp"];
+    if (!allowed.includes(file.type)) {
+      return NextResponse.json({ error: "Invalid file type" }, { status: 400 });
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      return NextResponse.json({ error: "File too large (max 2MB)" }, { status: 400 });
+    }
+
+    if (!existsSync(AVATAR_DIR)) mkdirSync(AVATAR_DIR, { recursive: true });
+
+    const bytes = await file.arrayBuffer();
+    writeFileSync(AVATAR_PATH, Buffer.from(bytes));
+
+    return NextResponse.json({ url: AVATAR_URL + "?t=" + Date.now() });
+  } catch (err) {
+    console.error("Avatar upload error:", err);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/browse/route.ts
+++ b/src/app/api/browse/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { promises as fs } from "fs";
+import { promises as fs, readFileSync } from "fs";
 import path from "path";
 
 const OPENCLAW_DIR = process.env.OPENCLAW_DIR || "/root/.openclaw";
@@ -11,6 +11,20 @@ interface FileEntry {
   modified: string;
 }
 
+function resolveWorkspacePath(workspace: string): string {
+  if (workspace === "workspace") return path.join(OPENCLAW_DIR, "workspace");
+  if (workspace.startsWith("workspace-")) return path.join(OPENCLAW_DIR, workspace);
+  if (workspace.startsWith("agent-")) {
+    const agentId = workspace.replace("agent-", "");
+    try {
+      const config = JSON.parse(readFileSync(path.join(OPENCLAW_DIR, "openclaw.json"), "utf-8"));
+      const agent = (config?.agents?.list as Array<{ id: string; workspace?: string }>)?.find(a => a.id === agentId);
+      if (agent?.workspace) return agent.workspace;
+    } catch {}
+  }
+  return path.join(OPENCLAW_DIR, workspace);
+}
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
@@ -18,9 +32,9 @@ export async function GET(request: NextRequest) {
     const relativePath = searchParams.get("path") || "";
     const fileContent = searchParams.get("content") === "true";
     const rawMode = searchParams.get("raw") === "true";
-    
+
     // Determine BASE_PATH based on workspace
-    const BASE_PATH = path.join(OPENCLAW_DIR, workspace);
+    const BASE_PATH = resolveWorkspacePath(workspace);
     
     // Validate workspace exists
     try {

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { callGateway, GatewayError, type CronListResult, type CronJob } from "@/lib/gateway";
 
 export const dynamic = "force-dynamic";
@@ -52,7 +52,7 @@ export async function GET() {
 }
 
 // PUT: enable/disable — not yet supported by gateway API
-export async function PUT(_request: NextRequest) {
+export async function PUT() {
   return NextResponse.json(
     { error: "Toggle not supported via gateway" },
     { status: 501 },
@@ -60,7 +60,7 @@ export async function PUT(_request: NextRequest) {
 }
 
 // DELETE: not yet supported by gateway API
-export async function DELETE(_request: NextRequest) {
+export async function DELETE() {
   return NextResponse.json(
     { error: "Delete not supported via gateway" },
     { status: 501 },

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { execSync } from "child_process";
+import { readFileSync } from "fs";
 
 function getGatewayConfig() {
   try {
-    const configRaw = require("fs").readFileSync((process.env.OPENCLAW_DIR || "/root/.openclaw") + "/openclaw.json", "utf-8");
+    const configRaw = readFileSync((process.env.OPENCLAW_DIR || "/root/.openclaw") + "/openclaw.json", "utf-8");
     const config = JSON.parse(configRaw);
     return {
       token: config.gateway?.auth?.token || "",

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,87 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
-import { execSync } from "child_process";
-import { readFileSync } from "fs";
+import { callGateway, GatewayError, type CronListResult, type CronJob } from "@/lib/gateway";
 
-function getGatewayConfig() {
-  try {
-    const configRaw = readFileSync((process.env.OPENCLAW_DIR || "/root/.openclaw") + "/openclaw.json", "utf-8");
-    const config = JSON.parse(configRaw);
-    return {
-      token: config.gateway?.auth?.token || "",
-      port: config.gateway?.port || 18789,
-    };
-  } catch {
-    return { token: "", port: 18789 };
-  }
-}
+export const dynamic = "force-dynamic";
 
-// GET: List all cron jobs from the OpenClaw gateway
-export async function GET() {
-  try {
-    const output = execSync("openclaw cron list --json --all 2>/dev/null", {
-      timeout: 10000,
-      encoding: "utf-8",
-    });
-
-    const data = JSON.parse(output);
-    const jobs = (data.jobs || []).map((job: Record<string, unknown>) => ({
-      id: job.id,
-      agentId: job.agentId || "main",
-      name: job.name || "Unnamed",
-      enabled: job.enabled ?? true,
-      createdAtMs: job.createdAtMs,
-      updatedAtMs: job.updatedAtMs,
-      schedule: job.schedule,
-      sessionTarget: job.sessionTarget,
-      payload: job.payload,
-      delivery: job.delivery,
-      state: job.state,
-      // Derived fields for the UI
-      description: formatDescription(job),
-      scheduleDisplay: formatSchedule(job.schedule as Record<string, unknown>),
-      timezone: (job.schedule as Record<string, string>)?.tz || "UTC",
-      nextRun: (job.state as Record<string, unknown>)?.nextRunAtMs
-        ? new Date((job.state as Record<string, number>).nextRunAtMs).toISOString()
-        : null,
-      lastRun: (job.state as Record<string, unknown>)?.lastRunAtMs
-        ? new Date((job.state as Record<string, number>).lastRunAtMs).toISOString()
-        : null,
-    }));
-
-    return NextResponse.json(jobs);
-  } catch (error) {
-    console.error("Error fetching cron jobs from gateway:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch cron jobs from OpenClaw gateway" },
-      { status: 500 }
-    );
-  }
-}
-
-function formatDescription(job: Record<string, unknown>): string {
-  const payload = job.payload as Record<string, unknown>;
-  if (!payload) return "";
-  if (payload.kind === "agentTurn") {
-    const msg = (payload.message as string) || "";
-    return msg.length > 120 ? msg.substring(0, 120) + "..." : msg;
-  }
-  if (payload.kind === "systemEvent") {
-    const text = (payload.text as string) || "";
-    return text.length > 120 ? text.substring(0, 120) + "..." : text;
-  }
-  return "";
-}
-
-function formatSchedule(schedule: Record<string, unknown>): string {
+function formatScheduleDisplay(schedule: CronJob["schedule"]): string {
   if (!schedule) return "Unknown";
   switch (schedule.kind) {
     case "cron":
       return `${schedule.expr}${schedule.tz ? ` (${schedule.tz})` : ""}`;
-    case "every":
-      const ms = schedule.everyMs as number;
+    case "every": {
+      const ms = schedule.everyMs ?? 0;
       if (ms >= 3600000) return `Every ${ms / 3600000}h`;
       if (ms >= 60000) return `Every ${ms / 60000}m`;
       return `Every ${ms / 1000}s`;
+    }
     case "at":
       return `Once at ${schedule.at}`;
     default:
@@ -89,54 +21,48 @@ function formatSchedule(schedule: Record<string, unknown>): string {
   }
 }
 
-// PUT: Toggle enable/disable a cron job
-export async function PUT(request: NextRequest) {
+export async function GET() {
   try {
-    const body = await request.json();
-    const { id, enabled } = body;
+    const result = await callGateway<CronListResult>("cron.list", {});
+    const jobs = (result.jobs ?? []).map((job) => ({
+      id: job.id,
+      agentId: job.agentId ?? "main",
+      name: job.name ?? "Unnamed",
+      enabled: job.enabled ?? true,
+      schedule: job.schedule,
+      state: job.state,
+      payload: job.payload,
+      scheduleDisplay: formatScheduleDisplay(job.schedule),
+      timezone: job.schedule?.tz ?? "UTC",
+      nextRun: job.state?.nextRunAtMs
+        ? new Date(job.state.nextRunAtMs).toISOString()
+        : null,
+      lastRun: job.state?.lastRunAtMs
+        ? new Date(job.state.lastRunAtMs).toISOString()
+        : null,
+    }));
 
-    if (!id) {
-      return NextResponse.json({ error: "Job ID is required" }, { status: 400 });
-    }
-
-    const action = enabled ? "enable" : "disable";
-    // Use openclaw CLI to update the job
-    const output = execSync(
-      `openclaw cron ${action} ${id} --json 2>/dev/null || openclaw cron update ${id} --enabled=${enabled} --json 2>/dev/null`,
-      { timeout: 10000, encoding: "utf-8" }
-    );
-
-    return NextResponse.json({ success: true, id, enabled });
+    return NextResponse.json(jobs);
   } catch (error) {
-    console.error("Error updating cron job:", error);
-    return NextResponse.json(
-      { error: "Failed to update cron job" },
-      { status: 500 }
-    );
+    const msg =
+      error instanceof GatewayError ? error.message : "Failed to fetch cron jobs";
+    console.error("Error fetching cron jobs:", error);
+    return NextResponse.json({ error: msg }, { status: 502 });
   }
 }
 
-// DELETE: Remove a cron job
-export async function DELETE(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const id = searchParams.get("id");
+// PUT: enable/disable — not yet supported by gateway API
+export async function PUT(_request: NextRequest) {
+  return NextResponse.json(
+    { error: "Toggle not supported via gateway" },
+    { status: 501 },
+  );
+}
 
-    if (!id) {
-      return NextResponse.json({ error: "Job ID is required" }, { status: 400 });
-    }
-
-    execSync(`openclaw cron remove ${id} 2>/dev/null`, {
-      timeout: 10000,
-      encoding: "utf-8",
-    });
-
-    return NextResponse.json({ success: true, deleted: id });
-  } catch (error) {
-    console.error("Error deleting cron job:", error);
-    return NextResponse.json(
-      { error: "Failed to delete cron job" },
-      { status: 500 }
-    );
-  }
+// DELETE: not yet supported by gateway API
+export async function DELETE(_request: NextRequest) {
+  return NextResponse.json(
+    { error: "Delete not supported via gateway" },
+    { status: 501 },
+  );
 }

--- a/src/app/api/cron/run/route.ts
+++ b/src/app/api/cron/run/route.ts
@@ -1,64 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
-import { execSync } from "child_process";
+import { callGateway, GatewayError } from "@/lib/gateway";
 
-async function createNotification(title: string, message: string, type: "info" | "success" | "warning" | "error" = "info") {
-  try {
-    await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/api/notifications`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title, message, type }),
-    });
-  } catch (error) {
-    console.error("Failed to create notification:", error);
-  }
-}
+export const dynamic = "force-dynamic";
 
-// POST: Trigger a cron job immediately
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { id } = body;
+    const { id } = body as { id?: string };
 
     if (!id) {
       return NextResponse.json({ error: "Job ID required" }, { status: 400 });
     }
 
-    // Validate id is safe (alphanumeric, hyphens, underscores only)
     if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
       return NextResponse.json({ error: "Invalid job ID" }, { status: 400 });
     }
 
-    const output = execSync(`openclaw cron run ${id} --force 2>&1`, {
-      timeout: 15000,
-      encoding: "utf-8",
-    });
+    await callGateway("cron.run", { id, mode: "force" });
 
-    // Create success notification
-    await createNotification(
-      "Cron Job Triggered",
-      `Job "${id}" has been manually executed.`,
-      "success"
-    );
-
-    return NextResponse.json({
-      success: true,
-      jobId: id,
-      message: output.trim() || "Job triggered successfully",
-    });
+    return NextResponse.json({ success: true, jobId: id });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to trigger job";
+    const msg =
+      error instanceof GatewayError ? error.message : "Failed to trigger job";
     console.error("Error triggering cron job:", error);
-    
-    // Create error notification
-    const body = await request.json();
-    await createNotification(
-      "Cron Job Failed",
-      `Failed to execute job "${body.id}": ${message}`,
-      "error"
-    );
-    
-    // Even if the command exits with non-zero, the job might have been triggered
-    // The openclaw CLI sometimes exits with error but still works
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
+    return NextResponse.json({ success: false, error: msg }, { status: 502 });
   }
 }

--- a/src/app/api/cron/runs/route.ts
+++ b/src/app/api/cron/runs/route.ts
@@ -1,73 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { execSync } from "child_process";
 
-// GET: Fetch run history for a cron job
+// Run history is not yet exposed via the gateway API.
+// The cron.list response includes lastRunAtMs and lastRunStatus on each job's state,
+// which is sufficient for the UI. This endpoint returns empty for now.
 export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const id = searchParams.get("id");
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get("id");
 
-    if (!id) {
-      return NextResponse.json({ error: "Job ID required" }, { status: 400 });
-    }
-
-    if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
-      return NextResponse.json({ error: "Invalid job ID" }, { status: 400 });
-    }
-
-    let runs: RunEntry[] = [];
-
-    try {
-      const output = execSync(`openclaw cron runs ${id} --json 2>/dev/null`, {
-        timeout: 10000,
-        encoding: "utf-8",
-      });
-
-      const data = JSON.parse(output);
-      const rawRuns: RawRun[] = data.runs || data || [];
-
-      runs = rawRuns.map((r: RawRun) => ({
-        id: r.id || `${id}-${r.startedAt}`,
-        jobId: id,
-        startedAt: r.startedAt || r.createdAt || null,
-        completedAt: r.completedAt || r.finishedAt || null,
-        status: r.status || "unknown",
-        durationMs:
-          r.durationMs ||
-          (r.startedAt && r.completedAt
-            ? new Date(r.completedAt).getTime() - new Date(r.startedAt).getTime()
-            : null),
-        error: r.error || null,
-      }));
-    } catch {
-      // Command might not support runs yet or no history — return empty
-      runs = [];
-    }
-
-    return NextResponse.json({ runs, total: runs.length });
-  } catch (error) {
-    console.error("Error fetching run history:", error);
-    return NextResponse.json({ error: "Failed to fetch run history" }, { status: 500 });
+  if (!id) {
+    return NextResponse.json({ error: "Job ID required" }, { status: 400 });
   }
-}
 
-interface RawRun {
-  id?: string;
-  startedAt?: string;
-  createdAt?: string;
-  completedAt?: string;
-  finishedAt?: string;
-  status?: string;
-  durationMs?: number;
-  error?: string;
-}
-
-interface RunEntry {
-  id: string;
-  jobId: string;
-  startedAt: string | null;
-  completedAt: string | null;
-  status: string;
-  durationMs: number | null;
-  error: string | null;
+  return NextResponse.json({ runs: [], total: 0 });
 }

--- a/src/app/api/files/delete/route.ts
+++ b/src/app/api/files/delete/route.ts
@@ -2,13 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { logActivity } from '@/lib/activities-db';
+import { resolveWorkspacePath } from '@/lib/paths';
 
-const OPENCLAW_DIR = process.env.OPENCLAW_DIR || '/root/.openclaw';
 
-const WORKSPACE_MAP: Record<string, string> = {
-  workspace: path.join(OPENCLAW_DIR, 'workspace'),
-  'mission-control': path.join(OPENCLAW_DIR, 'workspace', 'mission-control'),
-};
+
 
 // Protected paths - never allow deletion
 const PROTECTED = [
@@ -25,7 +22,7 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Missing path' }, { status: 400 });
     }
 
-    const base = WORKSPACE_MAP[workspace || 'workspace'];
+    const base = resolveWorkspacePath(workspace || 'workspace');
     if (!base) {
       return NextResponse.json({ error: 'Unknown workspace' }, { status: 400 });
     }

--- a/src/app/api/files/download/route.ts
+++ b/src/app/api/files/download/route.ts
@@ -2,13 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { logActivity } from '@/lib/activities-db';
+import { resolveWorkspacePath } from '@/lib/paths';
 
-const OPENCLAW_DIR = process.env.OPENCLAW_DIR || '/root/.openclaw';
 
-const WORKSPACE_MAP: Record<string, string> = {
-  workspace: path.join(OPENCLAW_DIR, 'workspace'),
-  'mission-control': path.join(OPENCLAW_DIR, 'workspace', 'mission-control'),
-};
+
 
 function getMimeType(filename: string): string {
   const ext = path.extname(filename).toLowerCase();
@@ -50,7 +47,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Missing path parameter' }, { status: 400 });
     }
 
-    const base = WORKSPACE_MAP[workspace];
+    const base = resolveWorkspacePath(workspace);
     if (!base) {
       return NextResponse.json({ error: 'Unknown workspace' }, { status: 400 });
     }

--- a/src/app/api/files/mkdir/route.ts
+++ b/src/app/api/files/mkdir/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { resolveWorkspacePath } from '@/lib/paths';
 
-const OPENCLAW_DIR = process.env.OPENCLAW_DIR || '/root/.openclaw';
 
-const WORKSPACE_MAP: Record<string, string> = {
-  workspace: path.join(OPENCLAW_DIR, 'workspace'),
-  'mission-control': path.join(OPENCLAW_DIR, 'workspace', 'mission-control'),
-};
+
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,7 +15,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing path or name' }, { status: 400 });
     }
 
-    const base = WORKSPACE_MAP[workspace || 'workspace'];
+    const base = resolveWorkspacePath(workspace || 'workspace');
     if (!base) {
       return NextResponse.json({ error: 'Unknown workspace' }, { status: 400 });
     }

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,8 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
-import { promises as fs } from "fs";
+import { promises as fs, readFileSync } from "fs";
 import path from "path";
 
 const OPENCLAW_DIR = process.env.OPENCLAW_DIR || "/root/.openclaw";
+
+function resolveWorkspacePath(workspace: string): string {
+  if (workspace === "workspace") return path.join(OPENCLAW_DIR, "workspace");
+  if (workspace.startsWith("workspace-")) return path.join(OPENCLAW_DIR, workspace);
+  if (workspace.startsWith("agent-")) {
+    const agentId = workspace.replace("agent-", "");
+    try {
+      const config = JSON.parse(readFileSync(path.join(OPENCLAW_DIR, "openclaw.json"), "utf-8"));
+      const agent = (config?.agents?.list as Array<{ id: string; workspace?: string }>)?.find(a => a.id === agentId);
+      if (agent?.workspace) return agent.workspace;
+    } catch {}
+  }
+  return path.join(OPENCLAW_DIR, workspace);
+}
 
 // Files to show in the memory browser
 const ROOT_FILES = ["MEMORY.md", "SOUL.md", "USER.md", "AGENTS.md", "TOOLS.md", "IDENTITY.md"];
@@ -101,7 +115,7 @@ export async function GET(request: NextRequest) {
 
   try {
     // Determine workspace path
-    const workspacePath = path.join(OPENCLAW_DIR, workspace);
+    const workspacePath = resolveWorkspacePath(workspace);
     
     // Validate workspace exists
     if (!(await fileExists(workspacePath))) {
@@ -165,8 +179,8 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const workspacePath = path.join(OPENCLAW_DIR, workspace);
-    
+    const workspacePath = resolveWorkspacePath(workspace);
+
     // Validate workspace exists
     if (!(await fileExists(workspacePath))) {
       return NextResponse.json(

--- a/src/app/api/files/upload/route.ts
+++ b/src/app/api/files/upload/route.ts
@@ -2,13 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { logActivity } from '@/lib/activities-db';
+import { resolveWorkspacePath } from '@/lib/paths';
 
-const OPENCLAW_DIR = process.env.OPENCLAW_DIR || '/root/.openclaw';
 
-const WORKSPACE_MAP: Record<string, string> = {
-  workspace: path.join(OPENCLAW_DIR, 'workspace'),
-  'mission-control': path.join(OPENCLAW_DIR, 'workspace', 'mission-control'),
-};
+
 
 
 export async function POST(request: NextRequest) {
@@ -22,7 +19,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'No files provided' }, { status: 400 });
     }
 
-    const base = WORKSPACE_MAP[workspace];
+    const base = resolveWorkspacePath(workspace);
     if (!base) {
       return NextResponse.json({ error: 'Unknown workspace' }, { status: 400 });
     }

--- a/src/app/api/files/upload/route.ts
+++ b/src/app/api/files/upload/route.ts
@@ -10,13 +10,6 @@ const WORKSPACE_MAP: Record<string, string> = {
   'mission-control': path.join(OPENCLAW_DIR, 'workspace', 'mission-control'),
 };
 
-function resolvePath(workspace: string, filePath: string): string | null {
-  const base = WORKSPACE_MAP[workspace];
-  if (!base) return null;
-  const full = path.resolve(base, filePath);
-  if (!full.startsWith(base)) return null; // path traversal check
-  return full;
-}
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/files/workspaces/route.ts
+++ b/src/app/api/files/workspaces/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-
-const OPENCLAW_DIR = process.env.OPENCLAW_DIR || '/root/.openclaw';
+import { OPENCLAW_DIR, OPENCLAW_WORKSPACE, OPENCLAW_CONFIG } from '@/lib/paths';
 
 interface Workspace {
   id: string;
@@ -14,24 +13,23 @@ interface Workspace {
 
 function getAgentInfo(workspacePath: string): { name: string; emoji: string } | null {
   const identityPath = path.join(workspacePath, 'IDENTITY.md');
-  
+
   if (!fs.existsSync(identityPath)) {
     return null;
   }
-  
+
   try {
     const content = fs.readFileSync(identityPath, 'utf-8');
-    
+
     const nameMatch = content.match(/- \*\*Name:\*\* (.+)/);
     const emojiMatch = content.match(/- \*\*Emoji:\*\* (.+)/);
-    
+
     let emoji = '📁';
     if (emojiMatch) {
-      // Extract just the emoji character (first few characters before any description)
       const emojiText = emojiMatch[1].trim();
-      emoji = emojiText.split(' ')[0]; // Take only the first part (the emoji)
+      emoji = emojiText.split(' ')[0];
     }
-    
+
     return {
       name: nameMatch ? nameMatch[1].trim() : '',
       emoji,
@@ -44,49 +42,75 @@ function getAgentInfo(workspacePath: string): { name: string; emoji: string } | 
 export async function GET() {
   try {
     const workspaces: Workspace[] = [];
-    
+
     // Main workspace
-    const mainWorkspace = path.join(OPENCLAW_DIR, 'workspace');
-    if (fs.existsSync(mainWorkspace)) {
-      const mainInfo = getAgentInfo(mainWorkspace);
+    if (fs.existsSync(OPENCLAW_WORKSPACE)) {
+      const mainInfo = getAgentInfo(OPENCLAW_WORKSPACE);
       workspaces.push({
         id: 'workspace',
-        name: 'Workspace Principal',
-        emoji: mainInfo?.emoji || '🦞',
-        path: mainWorkspace,
-        agentName: mainInfo?.name || 'Tenacitas',
+        name: process.env.NEXT_PUBLIC_AGENT_NAME || 'Main Workspace',
+        emoji: mainInfo?.emoji || (process.env.NEXT_PUBLIC_AGENT_EMOJI || '🤖'),
+        path: OPENCLAW_WORKSPACE,
+        agentName: mainInfo?.name || undefined,
       });
     }
-    
-    // Agent workspaces
-    const entries = fs.readdirSync(OPENCLAW_DIR, { withFileTypes: true });
-    
-    for (const entry of entries) {
-      if (entry.isDirectory() && entry.name.startsWith('workspace-')) {
-        const workspacePath = path.join(OPENCLAW_DIR, entry.name);
-        const agentInfo = getAgentInfo(workspacePath);
-        
-        const agentId = entry.name.replace('workspace-', '');
-        // Friendly workspace name: capitalize the directory id (e.g. "academic" → "Academic")
-        const workspaceLabel = agentId.charAt(0).toUpperCase() + agentId.slice(1);
 
-        workspaces.push({
-          id: entry.name,
-          name: workspaceLabel,
-          emoji: agentInfo?.emoji || '🤖',
-          path: workspacePath,
-          agentName: agentInfo?.name || undefined,
-        });
+    // Legacy: scan OPENCLAW_DIR for workspace-* subdirectories
+    if (fs.existsSync(OPENCLAW_DIR)) {
+      const entries = fs.readdirSync(OPENCLAW_DIR, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && entry.name.startsWith('workspace-')) {
+          const workspacePath = path.join(OPENCLAW_DIR, entry.name);
+          const agentInfo = getAgentInfo(workspacePath);
+          const agentId = entry.name.replace('workspace-', '');
+          const workspaceLabel = agentId.charAt(0).toUpperCase() + agentId.slice(1);
+
+          workspaces.push({
+            id: entry.name,
+            name: workspaceLabel,
+            emoji: agentInfo?.emoji || '🤖',
+            path: workspacePath,
+            agentName: agentInfo?.name || undefined,
+          });
+        }
       }
     }
-    
+
+    // Read agent workspaces from openclaw.json config
+    try {
+      const config = JSON.parse(fs.readFileSync(OPENCLAW_CONFIG, 'utf-8'));
+      const agentList: Array<{ id: string; name?: string; workspace?: string }> = config?.agents?.list || [];
+
+      for (const agent of agentList) {
+        if (!agent.workspace || agent.id === 'main') continue;
+        if (!fs.existsSync(agent.workspace)) continue;
+        // Skip if already added (avoid duplicates)
+        if (workspaces.some(w => w.path === agent.workspace)) continue;
+
+        const agentInfo = getAgentInfo(agent.workspace);
+        const label = agent.name
+          ? agent.name.charAt(0).toUpperCase() + agent.name.slice(1)
+          : agent.id.charAt(0).toUpperCase() + agent.id.slice(1);
+
+        workspaces.push({
+          id: `agent-${agent.id}`,
+          name: label,
+          emoji: agentInfo?.emoji || '🤖',
+          path: agent.workspace,
+          agentName: agentInfo?.name || agent.name || agent.id,
+        });
+      }
+    } catch {
+      // openclaw.json missing or invalid — skip agent workspaces
+    }
+
     // Sort: main first, then alphabetically
     workspaces.sort((a, b) => {
       if (a.id === 'workspace') return -1;
       if (b.id === 'workspace') return 1;
       return a.name.localeCompare(b.name);
     });
-    
+
     return NextResponse.json({ workspaces });
   } catch (error) {
     console.error('Failed to list workspaces:', error);

--- a/src/app/api/files/write/route.ts
+++ b/src/app/api/files/write/route.ts
@@ -7,13 +7,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { logActivity } from '@/lib/activities-db';
+import { resolveWorkspacePath } from '@/lib/paths';
 
-const OPENCLAW_DIR = process.env.OPENCLAW_DIR || '/root/.openclaw';
 
-const WORKSPACE_MAP: Record<string, string> = {
-  workspace: path.join(OPENCLAW_DIR, 'workspace'),
-  'mission-control': path.join(OPENCLAW_DIR, 'workspace', 'mission-control'),
-};
+
 
 export async function POST(request: NextRequest) {
   try {
@@ -24,7 +21,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing path or content' }, { status: 400 });
     }
 
-    const base = WORKSPACE_MAP[workspace || 'workspace'];
+    const base = resolveWorkspacePath(workspace || 'workspace');
     if (!base) {
       return NextResponse.json({ error: 'Unknown workspace' }, { status: 400 });
     }

--- a/src/app/api/git/route.ts
+++ b/src/app/api/git/route.ts
@@ -6,8 +6,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { promises as fs } from 'fs';
-import path from 'path';
 
 const execAsync = promisify(exec);
 const WORKSPACE = process.env.OPENCLAW_DIR ? `${process.env.OPENCLAW_DIR}/workspace` : '/root/.openclaw/workspace';
@@ -96,7 +94,7 @@ async function getRepoStatus(repoPath: string): Promise<RepoStatus> {
       remoteUrl,
       isDirty: staged.length > 0 || unstaged.length > 0 || untracked.length > 0,
     };
-  } catch (error) {
+  } catch {
     return {
       name,
       path: repoPath,
@@ -123,8 +121,6 @@ export async function GET() {
     return NextResponse.json({ error: 'Failed to get repos' }, { status: 500 });
   }
 }
-
-const ALLOWED_REPOS = [WORKSPACE + '/mission-control', WORKSPACE];
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -71,15 +71,15 @@ export async function GET() {
 
   // External URLs
   const urlChecks = await Promise.all([
-    checkUrl('https://tenacitas.cazaustre.dev'),
+    checkUrl('https://neuralops.ca'),
     checkUrl('https://api.anthropic.com', 3000),
   ]);
 
   checks.push({
-    name: 'tenacitas.cazaustre.dev',
+    name: 'neuralops.ca',
     status: urlChecks[0].status,
     latency: urlChecks[0].latency,
-    url: 'https://tenacitas.cazaustre.dev',
+    url: 'https://neuralops.ca',
   });
 
   checks.push({

--- a/src/app/api/jira/[key]/transition/route.ts
+++ b/src/app/api/jira/[key]/transition/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getTransitions, transitionIssue } from "@/lib/jira";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ key: string }> },
+) {
+  const { key } = await params;
+  const { transitionName } = (await request.json()) as { transitionName?: string };
+
+  if (!key || !/^[A-Z]+-\d+$/.test(key)) {
+    return NextResponse.json({ error: "Invalid issue key" }, { status: 400 });
+  }
+
+  try {
+    const transitions = await getTransitions(key);
+    const target = transitions.find(
+      (t) =>
+        t.name.toLowerCase() === (transitionName ?? "in progress").toLowerCase() ||
+        t.name.toLowerCase().includes("progress"),
+    );
+    if (!target) {
+      return NextResponse.json(
+        { error: `No transition matching "${transitionName}" found` },
+        { status: 404 },
+      );
+    }
+    await transitionIssue(key, target.id);
+    return NextResponse.json({ ok: true, transitionId: target.id, transitionName: target.name });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Transition failed";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+}

--- a/src/app/api/jira/auto-dispatch/route.ts
+++ b/src/app/api/jira/auto-dispatch/route.ts
@@ -46,7 +46,7 @@ async function dispatchToAgent(issue: JiraIssue, agentSlug: string): Promise<boo
     `Please implement the changes described in this ticket, then move the issue to Done when complete.`,
   ].join("\n");
 
-  const sessionKey = `agent:${agentSlug}:${issue.key.toLowerCase()}`;
+  const sessionKey = `agent:${agentSlug}:main`;
   await callGateway("sessions.send", { key: sessionKey, message, timeoutMs: 0 });
   return true;
 }

--- a/src/app/api/jira/auto-dispatch/route.ts
+++ b/src/app/api/jira/auto-dispatch/route.ts
@@ -1,0 +1,184 @@
+/**
+ * POST /api/jira/auto-dispatch
+ * Fetches all "To Do" issues (or a specific key), dispatches each to the main
+ * OpenClaw agent, transitions them to "In Progress", posts a Jira comment, and
+ * sends a Slack notification to #dev + a TenacitOS notification.
+ *
+ * Body (all optional):
+ *   { issueKey?: string, agentSlug?: string, dryRun?: boolean }
+ *
+ * If issueKey is provided, only that issue is dispatched.
+ * If dryRun is true, nothing is mutated — only the plan is returned.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getProjectIssues,
+  getSingleIssue,
+  getTransitions,
+  transitionIssue,
+  addJiraComment,
+  type JiraIssue,
+} from "@/lib/jira";
+import { sendSlackMessage } from "@/lib/slack";
+
+const PROJECT = "NEURALOPS";
+const DEFAULT_AGENT = "main";
+const NOTIFY_CHANNEL = "#dev";
+const DISPATCH_API = "/api/agents/dispatch";
+const NOTIFICATIONS_API = "/api/notifications";
+
+interface DispatchResult {
+  key: string;
+  summary: string;
+  dispatched: boolean;
+  transitioned: boolean;
+  slackNotified: boolean;
+  error?: string;
+}
+
+async function dispatchToAgent(
+  baseUrl: string,
+  issue: JiraIssue,
+  agentSlug: string,
+): Promise<boolean> {
+  const message = [
+    `Work on ${issue.key}: ${issue.summary}`,
+    ``,
+    `Jira: ${issue.url}`,
+    `Priority: ${issue.priority} | Type: ${issue.issuetype}`,
+    ``,
+    `Please implement the changes described in this ticket, then move the issue to Done when complete.`,
+  ].join("\n");
+
+  const res = await fetch(`${baseUrl}${DISPATCH_API}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ agentSlug, message, sessionSuffix: issue.key.toLowerCase() }),
+  });
+  const data = (await res.json()) as { ok: boolean };
+  return data.ok;
+}
+
+async function createInternalNotification(
+  baseUrl: string,
+  issue: JiraIssue,
+): Promise<void> {
+  await fetch(`${baseUrl}${NOTIFICATIONS_API}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: `Agent dispatched: ${issue.key}`,
+      message: `${issue.summary}`,
+      type: "info",
+      link: `/jira`,
+      metadata: { issueKey: issue.key, issueUrl: issue.url },
+    }),
+  });
+}
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => ({}))) as {
+    issueKey?: string;
+    agentSlug?: string;
+    dryRun?: boolean;
+  };
+
+  const agentSlug = body.agentSlug ?? DEFAULT_AGENT;
+  const dryRun = body.dryRun ?? false;
+
+  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+
+  let issues: JiraIssue[];
+  try {
+    if (body.issueKey) {
+      const single = await getSingleIssue(body.issueKey);
+      if (!single) {
+        return NextResponse.json(
+          { error: `Issue not found: ${body.issueKey}` },
+          { status: 404 },
+        );
+      }
+      issues = [single];
+    } else {
+      const all = await getProjectIssues(PROJECT);
+      issues = all.filter((i) => i.status === "To Do");
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to fetch issues";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+
+  if (issues.length === 0) {
+    return NextResponse.json({ dispatched: [], message: "No To Do issues found" });
+  }
+
+  const results: DispatchResult[] = [];
+
+  for (const issue of issues) {
+    const result: DispatchResult = {
+      key: issue.key,
+      summary: issue.summary,
+      dispatched: false,
+      transitioned: false,
+      slackNotified: false,
+    };
+
+    if (dryRun) {
+      result.dispatched = true;
+      result.transitioned = true;
+      result.slackNotified = true;
+      results.push(result);
+      continue;
+    }
+
+    try {
+      // 1. Dispatch to agent
+      result.dispatched = await dispatchToAgent(baseUrl, issue, agentSlug);
+
+      // 2. Transition to "In Progress" (only if not already)
+      if (issue.status === "To Do") {
+        const transitions = await getTransitions(issue.key);
+        const inProgress = transitions.find(
+          (t) =>
+            t.name.toLowerCase().includes("progress") ||
+            t.name.toLowerCase() === "in progress",
+        );
+        if (inProgress) {
+          await transitionIssue(issue.key, inProgress.id);
+          result.transitioned = true;
+        }
+      } else {
+        result.transitioned = true;
+      }
+
+      // 3. Post comment on Jira issue
+      await addJiraComment(
+        issue.key,
+        `🤖 OpenClaw agent dispatched to work on this issue.\nAgent: ${agentSlug} | Session: ${issue.key.toLowerCase()}\nAuto-dispatched via TenacitOS Mission Control.`,
+      ).catch(() => null);
+
+      // 4. Send Slack notification
+      const slackText = `🤖 *${issue.key}* dispatched to agent \`${agentSlug}\`\n*${issue.summary}*\n<${issue.url}|View in Jira>`;
+      const slackResult = await sendSlackMessage(NOTIFY_CHANNEL, slackText);
+      result.slackNotified = slackResult.ok;
+
+      // 5. Create TenacitOS notification
+      await createInternalNotification(baseUrl, issue).catch(() => null);
+    } catch (err) {
+      result.error = err instanceof Error ? err.message : String(err);
+    }
+
+    results.push(result);
+  }
+
+  const summary = {
+    total: results.length,
+    dispatched: results.filter((r) => r.dispatched).length,
+    errors: results.filter((r) => r.error).length,
+    dryRun,
+  };
+
+  return NextResponse.json({ summary, dispatched: results });
+}

--- a/src/app/api/jira/auto-dispatch/route.ts
+++ b/src/app/api/jira/auto-dispatch/route.ts
@@ -20,11 +20,11 @@ import {
   type JiraIssue,
 } from "@/lib/jira";
 import { sendSlackMessage } from "@/lib/slack";
+import { callGateway } from "@/lib/gateway";
 
 const PROJECT = "NEURALOPS";
 const DEFAULT_AGENT = "main";
 const NOTIFY_CHANNEL = "#dev";
-const DISPATCH_API = "/api/agents/dispatch";
 const NOTIFICATIONS_API = "/api/notifications";
 
 interface DispatchResult {
@@ -36,11 +36,7 @@ interface DispatchResult {
   error?: string;
 }
 
-async function dispatchToAgent(
-  baseUrl: string,
-  issue: JiraIssue,
-  agentSlug: string,
-): Promise<boolean> {
+async function dispatchToAgent(issue: JiraIssue, agentSlug: string): Promise<boolean> {
   const message = [
     `Work on ${issue.key}: ${issue.summary}`,
     ``,
@@ -50,13 +46,9 @@ async function dispatchToAgent(
     `Please implement the changes described in this ticket, then move the issue to Done when complete.`,
   ].join("\n");
 
-  const res = await fetch(`${baseUrl}${DISPATCH_API}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ agentSlug, message, sessionSuffix: issue.key.toLowerCase() }),
-  });
-  const data = (await res.json()) as { ok: boolean };
-  return data.ok;
+  const sessionKey = `agent:${agentSlug}:${issue.key.toLowerCase()}`;
+  await callGateway("sessions.send", { key: sessionKey, message, timeoutMs: 0 });
+  return true;
 }
 
 async function createInternalNotification(
@@ -135,7 +127,7 @@ export async function POST(request: NextRequest) {
 
     try {
       // 1. Dispatch to agent
-      result.dispatched = await dispatchToAgent(baseUrl, issue, agentSlug);
+      result.dispatched = await dispatchToAgent(issue, agentSlug);
 
       // 2. Transition to "In Progress" (only if not already)
       if (issue.status === "To Do") {

--- a/src/app/api/jira/auto-dispatch/route.ts
+++ b/src/app/api/jira/auto-dispatch/route.ts
@@ -21,11 +21,11 @@ import {
 } from "@/lib/jira";
 import { sendSlackMessage } from "@/lib/slack";
 import { callGateway } from "@/lib/gateway";
+import { createNotification } from "@/lib/notifications";
 
 const PROJECT = "NEURALOPS";
 const DEFAULT_AGENT = "main";
 const NOTIFY_CHANNEL = "#dev";
-const NOTIFICATIONS_API = "/api/notifications";
 
 interface DispatchResult {
   key: string;
@@ -51,23 +51,6 @@ async function dispatchToAgent(issue: JiraIssue, agentSlug: string): Promise<boo
   return true;
 }
 
-async function createInternalNotification(
-  baseUrl: string,
-  issue: JiraIssue,
-): Promise<void> {
-  await fetch(`${baseUrl}${NOTIFICATIONS_API}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      title: `Agent dispatched: ${issue.key}`,
-      message: `${issue.summary}`,
-      type: "info",
-      link: `/jira`,
-      metadata: { issueKey: issue.key, issueUrl: issue.url },
-    }),
-  });
-}
-
 export const dynamic = "force-dynamic";
 
 export async function POST(request: NextRequest) {
@@ -79,8 +62,6 @@ export async function POST(request: NextRequest) {
 
   const agentSlug = body.agentSlug ?? DEFAULT_AGENT;
   const dryRun = body.dryRun ?? false;
-
-  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
 
   let issues: JiraIssue[];
   try {
@@ -157,7 +138,13 @@ export async function POST(request: NextRequest) {
       result.slackNotified = slackResult.ok;
 
       // 5. Create TenacitOS notification
-      await createInternalNotification(baseUrl, issue).catch(() => null);
+      await createNotification({
+        title: `Agent dispatched: ${issue.key}`,
+        message: issue.summary,
+        type: "info",
+        link: `/jira`,
+        metadata: { issueKey: issue.key, issueUrl: issue.url },
+      }).catch(() => null);
     } catch (err) {
       result.error = err instanceof Error ? err.message : String(err);
     }

--- a/src/app/api/jira/issues/route.ts
+++ b/src/app/api/jira/issues/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getProjectIssues } from "@/lib/jira";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const issues = await getProjectIssues("NEURALOPS");
+    return NextResponse.json({ issues });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Failed to fetch Jira issues";
+    console.error("Jira error:", error);
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+}

--- a/src/app/api/jira/webhook/route.ts
+++ b/src/app/api/jira/webhook/route.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /api/jira/webhook
+ * Receives Jira automation webhook events and triggers auto-dispatch for
+ * issues that land in "To Do" status.
+ *
+ * Configure in Jira: Project Settings → Automation → Webhook
+ * URL: https://<your-domain>/api/jira/webhook
+ * Header: X-Jira-Webhook-Secret: <JIRA_WEBHOOK_SECRET env var>
+ *
+ * Supported events: issue_created, issue_updated
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getSingleIssue } from "@/lib/jira";
+import { sendSlackMessage } from "@/lib/slack";
+
+const NOTIFY_CHANNEL = "#dev";
+
+interface JiraWebhookPayload {
+  webhookEvent?: string;
+  issue?: {
+    key: string;
+    fields?: {
+      summary?: string;
+      status?: { name: string };
+      priority?: { name: string };
+      issuetype?: { name: string };
+    };
+  };
+  changelog?: {
+    items?: Array<{
+      field: string;
+      fromString?: string;
+      toString?: string;
+    }>;
+  };
+}
+
+function validateSecret(request: NextRequest): boolean {
+  const secret = process.env.JIRA_WEBHOOK_SECRET;
+  if (!secret) return true; // no secret configured → open (dev mode)
+  const header = request.headers.get("x-jira-webhook-secret");
+  return header === secret;
+}
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  if (!validateSecret(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let payload: JiraWebhookPayload;
+  try {
+    payload = (await request.json()) as JiraWebhookPayload;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const event = payload.webhookEvent;
+  const issueKey = payload.issue?.key;
+
+  if (!issueKey) {
+    return NextResponse.json({ skipped: true, reason: "no issue key" });
+  }
+
+  // Only act on issue_created or status transitions into "To Do"
+  const isCreated = event === "jira:issue_created";
+  const isMovedToToDo =
+    event === "jira:issue_updated" &&
+    payload.changelog?.items?.some(
+      (item) =>
+        item.field === "status" &&
+        item.toString?.toLowerCase() === "to do",
+    );
+
+  if (!isCreated && !isMovedToToDo) {
+    return NextResponse.json({ skipped: true, reason: `event not actionable: ${event}` });
+  }
+
+  // Fetch the full issue to confirm current status
+  const issue = await getSingleIssue(issueKey).catch(() => null);
+  if (!issue) {
+    return NextResponse.json({ skipped: true, reason: "issue fetch failed" });
+  }
+
+  if (issue.status !== "To Do") {
+    return NextResponse.json({ skipped: true, reason: `status is "${issue.status}", not "To Do"` });
+  }
+
+  // Trigger auto-dispatch for this issue
+  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+  const dispatchRes = await fetch(`${baseUrl}/api/jira/auto-dispatch`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ issueKey }),
+  });
+
+  const dispatchData = (await dispatchRes.json()) as {
+    summary?: { dispatched: number; errors: number };
+    error?: string;
+  };
+
+  if (!dispatchRes.ok || dispatchData.error) {
+    // Notify Slack about the failure
+    await sendSlackMessage(
+      NOTIFY_CHANNEL,
+      `⚠️ Jira webhook received for *${issueKey}* but auto-dispatch failed: ${dispatchData.error ?? "unknown error"}`,
+    ).catch(() => null);
+    return NextResponse.json({ ok: false, error: dispatchData.error }, { status: 502 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    issueKey,
+    event,
+    dispatch: dispatchData.summary,
+  });
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,43 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
-import fs from 'fs/promises';
-import path from 'path';
 import { randomUUID } from 'crypto';
+import {
+  loadNotifications,
+  saveNotifications,
+  type Notification,
+} from '@/lib/notifications';
 
-const DATA_PATH = path.join(process.cwd(), 'data', 'notifications.json');
-
-export interface Notification {
-  id: string;
-  timestamp: string;
-  title: string;
-  message: string;
-  type: 'info' | 'success' | 'warning' | 'error';
-  read: boolean;
-  link?: string;
-  metadata?: Record<string, unknown>;
-}
+export type { Notification };
 
 interface NotificationsResponse {
   notifications: Notification[];
   unreadCount: number;
-}
-
-async function loadNotifications(): Promise<Notification[]> {
-  try {
-    const data = await fs.readFile(DATA_PATH, 'utf-8');
-    return JSON.parse(data);
-  } catch {
-    return [];
-  }
-}
-
-async function saveNotifications(notifications: Notification[]): Promise<void> {
-  const dir = path.dirname(DATA_PATH);
-  try {
-    await fs.access(dir);
-  } catch {
-    await fs.mkdir(dir, { recursive: true });
-  }
-  await fs.writeFile(DATA_PATH, JSON.stringify(notifications, null, 2));
 }
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/office/route.ts
+++ b/src/app/api/office/route.ts
@@ -189,7 +189,7 @@ export async function GET() {
     // Try gateway first, fallback to file-based
     const gatewayStatus = await getAgentStatusFromGateway();
 
-    const agents = config.agents.list.map((agent: any) => {
+    const agents = config.agents.list.map((agent: { id: string; name?: string; workspace: string }) => {
       const agentInfo = AGENT_CONFIG[agent.id as keyof typeof AGENT_CONFIG] || {
         emoji: "🤖",
         color: "#666",

--- a/src/app/api/office/route.ts
+++ b/src/app/api/office/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { readFileSync, statSync, readdirSync } from "fs";
+import { readFileSync, statSync } from "fs";
 import { join } from "path";
 
 export const dynamic = "force-dynamic";
@@ -175,7 +175,7 @@ function getAgentStatusFromFiles(
     } else {
       return { isActive: false, currentTask: "SLEEPING: zzZ...", lastSeen };
     }
-  } catch (error) {
+  } catch {
     // No memory file or error reading
     return { isActive: false, currentTask: "SLEEPING: zzZ...", lastSeen: 0 };
   }

--- a/src/app/api/office/route.ts
+++ b/src/app/api/office/route.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 export const dynamic = "force-dynamic";
 
 const AGENT_CONFIG = {
-  main: { emoji: "🦞", color: "#ff6b35", name: "Tenacitas", role: "Boss" },
+  main: { emoji: "🤖", color: "#ff6b35", name: process.env.NEXT_PUBLIC_AGENT_NAME || "NeuralOps", role: "Boss" },
   academic: {
     emoji: "🎓",
     color: "#4ade80",

--- a/src/app/api/slack/channels/route.ts
+++ b/src/app/api/slack/channels/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import {
+  SLACK_CHANNELS,
+  resolveChannelId,
+  getChannelHistory,
+  getUserInfo,
+  type SlackMessage,
+  type SlackUserInfo,
+} from "@/lib/slack";
+
+export const dynamic = "force-dynamic";
+
+export interface ChannelResult {
+  name: string;
+  channelId: string | null;
+  messages: Array<SlackMessage & { userInfo?: SlackUserInfo | null }>;
+  error?: string;
+}
+
+export async function GET() {
+  const results = await Promise.allSettled(
+    SLACK_CHANNELS.map(async (channelName): Promise<ChannelResult> => {
+      const channelId = await resolveChannelId(channelName);
+      if (!channelId) {
+        return {
+          name: channelName,
+          channelId: null,
+          messages: [],
+          error: "Channel not found — set SLACK_CHANNEL_* env vars",
+        };
+      }
+
+      const messages = await getChannelHistory(channelId, 10);
+      const messagesWithUsers = await Promise.all(
+        messages.map(async (msg) => {
+          const userInfo = msg.user
+            ? await getUserInfo(msg.user).catch(() => null)
+            : null;
+          return { ...msg, userInfo };
+        }),
+      );
+
+      return { name: channelName, channelId, messages: messagesWithUsers };
+    }),
+  );
+
+  const channels: ChannelResult[] = results.map((r, i) => {
+    if (r.status === "rejected") {
+      return {
+        name: SLACK_CHANNELS[i]!,
+        channelId: null,
+        messages: [],
+        error: String(r.reason),
+      };
+    }
+    return r.value;
+  });
+
+  return NextResponse.json({ channels });
+}

--- a/src/app/api/system/monitor/route.ts
+++ b/src/app/api/system/monitor/route.ts
@@ -60,7 +60,7 @@ function normalizePm2Status(status: string): string {
 
 // Friendly display names for PM2 process names
 const SERVICE_DESCRIPTIONS: Record<string, string> = {
-  "mission-control": "Mission Control – Tenacitas Dashboard",
+  "mission-control": "NeuralOps Mission Control Dashboard",
   classvault: "ClassVault – LMS Platform",
   "content-vault": "Content Vault – Draft Management Webapp",
   "postiz-simple": "Postiz – Social Media Scheduler",
@@ -80,20 +80,73 @@ export async function GET() {
     const freeMem = os.freemem();
     const usedMem = totalMem - freeMem;
 
-    // ── Disk ─────────────────────────────────────────────────────────────────
+    // ── Disk (all real filesystems) ───────────────────────────────────────────
+    interface DiskEntry { mountpoint: string; total: number; used: number; free: number; percent: number; }
+    const disks: DiskEntry[] = [];
     let diskTotal = 100;
     let diskUsed = 0;
     let diskFree = 100;
+    let diskPercent = 0;
     try {
-      const { stdout } = await execAsync("df -BG / | tail -1");
-      const parts = stdout.trim().split(/\s+/);
-      diskTotal = parseInt(parts[1].replace("G", ""));
-      diskUsed = parseInt(parts[2].replace("G", ""));
-      diskFree = parseInt(parts[3].replace("G", ""));
+      // Exclude pseudo/virtual filesystems
+      const { stdout } = await execAsync(
+        "df -BG --output=target,size,used,avail,pcent,fstype 2>/dev/null | tail -n +2"
+      );
+      const EXCLUDE_FS = /^(tmpfs|devtmpfs|squashfs|sysfs|proc|devpts|cgroup|pstore|securityfs|efivarfs|hugetlbfs|mqueue|binfmt_misc|fusectl|configfs|ramfs|udev|sunrpc|overlay)$/i;
+      const EXCLUDE_MOUNT = /^(\/dev|\/sys|\/proc|\/run\/|\/snap\/)/;
+      for (const line of stdout.trim().split('\n')) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 6) continue;
+        const [target, sizeRaw, usedRaw, availRaw, pctRaw, fstype] = parts;
+        if (EXCLUDE_FS.test(fstype) || EXCLUDE_MOUNT.test(target)) continue;
+        const total = parseInt(sizeRaw.replace('G', '')) || 0;
+        if (total === 0) continue;
+        const used = parseInt(usedRaw.replace('G', '')) || 0;
+        const free = parseInt(availRaw.replace('G', '')) || 0;
+        const percent = parseInt(pctRaw.replace('%', '')) || 0;
+        disks.push({ mountpoint: target, total, used, free, percent });
+      }
+      // Deduplicate by size+used (overlay + physical device often same data)
+      const seen = new Set<string>();
+      const unique = disks.filter(d => {
+        const key = `${d.total}-${d.used}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      disks.length = 0;
+      disks.push(...unique);
+
+      // Primary disk = root or first entry
+      const primary = disks.find(d => d.mountpoint === '/') || disks[0];
+      if (primary) {
+        diskTotal = primary.total;
+        diskUsed = primary.used;
+        diskFree = primary.free;
+        diskPercent = primary.percent;
+      }
     } catch (error) {
       console.error("Failed to get disk stats:", error);
     }
-    const diskPercent = (diskUsed / diskTotal) * 100;
+    if (disks.length === 0) {
+      disks.push({ mountpoint: '/', total: diskTotal, used: diskUsed, free: diskFree, percent: diskPercent });
+    }
+
+    // ── Swap ──────────────────────────────────────────────────────────────────
+    let swapTotal = 0;
+    let swapUsed = 0;
+    let swapFree = 0;
+    try {
+      const { readFileSync } = await import('fs');
+      const meminfo = readFileSync('/proc/meminfo', 'utf-8');
+      const swapTotalMatch = meminfo.match(/SwapTotal:\s+(\d+)\s+kB/);
+      const swapFreeMatch = meminfo.match(/SwapFree:\s+(\d+)\s+kB/);
+      if (swapTotalMatch) swapTotal = parseInt(swapTotalMatch[1]) / 1024 / 1024; // GB
+      if (swapFreeMatch) swapFree = parseInt(swapFreeMatch[1]) / 1024 / 1024;
+      swapUsed = swapTotal - swapFree;
+    } catch {
+      // swap info unavailable
+    }
 
     // ── Network (real stats from /proc/net/dev) ───────────────────────────────
     let network = { rx: 0, tx: 0 };
@@ -294,12 +347,19 @@ export async function GET() {
         free: parseFloat((freeMem / 1024 / 1024 / 1024).toFixed(2)),
         cached: 0,
       },
+      swap: {
+        total: parseFloat(swapTotal.toFixed(2)),
+        used: parseFloat(swapUsed.toFixed(2)),
+        free: parseFloat(swapFree.toFixed(2)),
+        percent: swapTotal > 0 ? parseFloat(((swapUsed / swapTotal) * 100).toFixed(1)) : 0,
+      },
       disk: {
         total: diskTotal,
         used: diskUsed,
         free: diskFree,
         percent: diskPercent,
       },
+      disks,
       network,
       systemd: services, // kept field name for backwards compat with page.tsx
       tailscale: {
@@ -311,7 +371,7 @@ export async function GET() {
             : [
                 { ip: "100.122.105.85", hostname: "srv1328267", os: "linux", online: true },
                 { ip: "100.106.86.52", hostname: "iphone182", os: "iOS", online: true },
-                { ip: "100.72.14.113", hostname: "macbook-pro-de-carlos", os: "macOS", online: true },
+                { ip: "100.72.14.113", hostname: `macbook-pro-de-${(process.env.NEXT_PUBLIC_OWNER_USERNAME || 'owner').toLowerCase()}`, os: "macOS", online: true },
               ],
       },
       firewall: {

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -169,7 +169,7 @@ export async function POST(request: Request) {
     }
     
     return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
-  } catch (error) {
+  } catch {
     return NextResponse.json({ error: 'Action failed' }, { status: 500 });
   }
 }

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -144,7 +144,7 @@ export async function POST(request: Request) {
       }
       
       // Verify current password
-      const currentPassMatch = envContent.match(/AUTH_PASSWORD=(.+)/);
+      const currentPassMatch = envContent.match(/ADMIN_PASSWORD=(.+)/);
       const storedPassword = currentPassMatch?.[1]?.trim();
       
       if (storedPassword !== currentPassword) {
@@ -153,8 +153,8 @@ export async function POST(request: Request) {
       
       // Update password
       const newEnvContent = envContent.replace(
-        /AUTH_PASSWORD=.*/,
-        `AUTH_PASSWORD=${newPassword}`
+        /ADMIN_PASSWORD=.*/,
+        `ADMIN_PASSWORD=${newPassword}`
       );
       
       fs.writeFileSync(ENV_LOCAL_PATH, newEnvContent);

--- a/src/app/api/system/stats/route.ts
+++ b/src/app/api/system/stats/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
 
     // Systemd Services (count active ones)
     let activeServices = 0;
-    let totalServices = SYSTEMD_SERVICES.length;
+    const totalServices = SYSTEMD_SERVICES.length;
     try {
       for (const name of SYSTEMD_SERVICES) {
         const { stdout } = await execAsync(`systemctl is-active ${name} 2>/dev/null || true`);

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,12 +1,13 @@
 /**
- * Weather API - Madrid
+ * Weather API - IP-based geolocation
  * GET /api/weather
- * Uses Open-Meteo (free, no API key)
+ * Uses ip-api.com for geolocation + Open-Meteo for weather (both free, no API key)
  */
 import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
 
 // Cache weather data for 10 minutes
-let cache: { data: unknown; ts: number } | null = null;
+let cache: { data: unknown; ts: number; city: string } | null = null;
 const CACHE_DURATION = 10 * 60 * 1000;
 
 const WMO_CODES: Record<number, { label: string; emoji: string }> = {
@@ -29,19 +30,50 @@ const WMO_CODES: Record<number, { label: string; emoji: string }> = {
   81: { label: "Showers", emoji: "🌧️" },
   82: { label: "Heavy showers", emoji: "⛈️" },
   95: { label: "Thunderstorm", emoji: "⛈️" },
-  96: { label: "Thunderstorm with hail", emoji: "⛈️" },
+  96: { label: "Thunderstorm with hail", emoji: "⛈��" },
   99: { label: "Thunderstorm with heavy hail", emoji: "⛈️" },
 };
 
-export async function GET() {
+async function geolocateIp(ip: string): Promise<{ lat: number; lon: number; city: string; timezone: string } | null> {
+  // Skip private/loopback IPs
+  if (!ip || ip === 'unknown' || ip.startsWith('127.') || ip.startsWith('10.') || ip.startsWith('192.168.') || ip === '::1') {
+    return null;
+  }
+  try {
+    const res = await fetch(`http://ip-api.com/json/${ip}?fields=status,lat,lon,city,timezone`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    const data = await res.json();
+    if (data.status === 'success') {
+      return { lat: data.lat, lon: data.lon, city: data.city, timezone: data.timezone };
+    }
+  } catch {
+    // geolocation failed — fall through to default
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
   // Return cache if valid
   if (cache && Date.now() - cache.ts < CACHE_DURATION) {
     return NextResponse.json(cache.data);
   }
 
+  // Get client IP
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+
+  // Try to geolocate, fall back to server location
+  const geo = await geolocateIp(ip);
+  const lat = geo?.lat ?? 43.7001;    // Toronto fallback
+  const lon = geo?.lon ?? -79.4163;
+  const city = geo?.city ?? 'Unknown';
+  const timezone = geo?.timezone ?? 'America/Toronto';
+
   try {
-    // Madrid coordinates: 40.4168° N, 3.7038° W
-    const url = 'https://api.open-meteo.com/v1/forecast?latitude=40.4168&longitude=-3.7038&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,wind_speed_10m,precipitation&daily=temperature_2m_max,temperature_2m_min,weather_code&timezone=Europe%2FMadrid&forecast_days=3';
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,wind_speed_10m,precipitation&daily=temperature_2m_max,temperature_2m_min,weather_code&timezone=${encodeURIComponent(timezone)}&forecast_days=3`;
 
     const res = await fetch(url, { next: { revalidate: 600 } });
     const json = await res.json();
@@ -52,7 +84,7 @@ export async function GET() {
     const wmo = WMO_CODES[current.weather_code] || { label: "Unknown", emoji: "🌡️" };
 
     const data = {
-      city: "Madrid",
+      city,
       temp: Math.round(current.temperature_2m),
       feels_like: Math.round(current.apparent_temperature),
       humidity: current.relative_humidity_2m,
@@ -69,7 +101,7 @@ export async function GET() {
       updated: new Date().toISOString(),
     };
 
-    cache = { data, ts: Date.now() };
+    cache = { data, ts: Date.now(), city };
     return NextResponse.json(data);
   } catch (error) {
     console.error('[weather] Error:', error);

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -7,7 +7,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 // Cache weather data for 10 minutes
-let cache: { data: unknown; ts: number; city: string } | null = null;
+const cache = new Map<string, { data: unknown; ts: number }>();
 const CACHE_DURATION = 10 * 60 * 1000;
 
 const WMO_CODES: Record<number, { label: string; emoji: string }> = {
@@ -54,11 +54,6 @@ async function geolocateIp(ip: string): Promise<{ lat: number; lon: number; city
 }
 
 export async function GET(request: NextRequest) {
-  // Return cache if valid
-  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
-    return NextResponse.json(cache.data);
-  }
-
   // Get client IP
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
@@ -71,6 +66,13 @@ export async function GET(request: NextRequest) {
   const lon = geo?.lon ?? -79.4163;
   const city = geo?.city ?? 'Unknown';
   const timezone = geo?.timezone ?? 'America/Toronto';
+
+  // Return cached response for this IP/location
+  const cacheKey = ip + ':' + city;
+  const cached = cache.get(cacheKey);
+  if (cached && Date.now() - cached.ts < CACHE_DURATION) {
+    return NextResponse.json(cached.data);
+  }
 
   try {
     const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,wind_speed_10m,precipitation&daily=temperature_2m_max,temperature_2m_min,weather_code&timezone=${encodeURIComponent(timezone)}&forecast_days=3`;
@@ -101,7 +103,7 @@ export async function GET(request: NextRequest) {
       updated: new Date().toISOString(),
     };
 
-    cache = { data, ts: Date.now(), city };
+    cache.set(cacheKey, { data, ts: Date.now() });
     return NextResponse.json(data);
   } catch (error) {
     console.error('[weather] Error:', error);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter, Sora, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -22,7 +22,6 @@ export const metadata: Metadata = {
   title: "Mission Control - OpenClaw",
   description: "Your OpenClaw agent dashboard",
   manifest: "/manifest.json",
-  themeColor: "#1a1a2e",
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
@@ -30,6 +29,10 @@ export const metadata: Metadata = {
   icons: {
     apple: "/apple-touch-icon.png",
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#1a1a2e",
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <head>
-        <script dangerouslySetInnerHTML={{__html:`if("serviceWorker"in navigator)navigator.serviceWorker.register("/sw.js")`}} />
+        <script dangerouslySetInnerHTML={{__html:`if("serviceWorker"in navigator&&(location.protocol==="http:"||location.protocol==="https:"))navigator.serviceWorker.register("/sw.js")`}} />
       </head>
       <body 
         className={`${inter.variable} ${sora.variable} ${jetbrainsMono.variable} font-sans`}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -30,10 +30,10 @@ function LoginForm() {
         router.push(from);
         router.refresh();
       } else {
-        setError("Contraseña incorrecta");
+        setError("Incorrect password");
       }
     } catch {
-      setError("Error de conexión");
+      setError("Connection error");
     }
 
     setLoading(false);
@@ -70,7 +70,7 @@ function LoginForm() {
           className="text-sm"
           style={{ color: 'var(--text-secondary)' }}
         >
-          Introduce la contraseña para acceder
+          Enter your password to access
         </p>
       </div>
 
@@ -91,7 +91,7 @@ function LoginForm() {
               border: '1px solid var(--border)',
               color: 'var(--text-primary)',
             }}
-            placeholder="Contraseña"
+            placeholder="Password"
             required
           />
         </div>
@@ -118,7 +118,7 @@ function LoginForm() {
             color: 'white',
           }}
         >
-          {loading ? "Verificando..." : "Entrar"}
+          {loading ? "Verifying..." : "Sign in"}
         </button>
       </form>
 
@@ -127,7 +127,7 @@ function LoginForm() {
         className="text-center text-xs mt-6"
         style={{ color: 'var(--text-muted)' }}
       >
-        Tenacitas Agent Dashboard
+        Tenacitos Agent Dashboard
       </p>
     </div>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -54,7 +54,7 @@ function LoginForm() {
             className="w-7 h-7" 
             style={{ color: 'var(--accent)' }} 
           />
-          <span className="text-2xl">🦞</span>
+          <span className="text-2xl">🤖</span>
           <h1 
             className="text-xl font-bold"
             style={{ 
@@ -127,7 +127,7 @@ function LoginForm() {
         className="text-center text-xs mt-6"
         style={{ color: 'var(--text-muted)' }}
       >
-        Tenacitos Agent Dashboard
+        NeuralOps Agent Dashboard
       </p>
     </div>
   );

--- a/src/app/office/page.tsx
+++ b/src/app/office/page.tsx
@@ -1,9 +1,18 @@
-import Office3D from '@/components/Office3D/Office3D';
+'use client';
 
-export const metadata = {
-  title: 'The Office 3D | Mission Control',
-  description: 'Visualiza tus agentes trabajando en tiempo real en un entorno 3D',
-};
+import dynamic from 'next/dynamic';
+
+const Office3D = dynamic(() => import('@/components/Office3D/Office3D'), {
+  ssr: false,
+  loading: () => (
+    <div className="fixed inset-0 bg-gray-900 flex items-center justify-center">
+      <div className="text-center text-white">
+        <div className="text-4xl mb-4">🏢</div>
+        <p className="text-lg font-medium opacity-70">Loading The Office...</p>
+      </div>
+    </div>
+  ),
+});
 
 export default function OfficePage() {
   return <Office3D />;

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { format, subDays, eachDayOfInterval, startOfWeek, endOfWeek } from "date-fns";
+import { format, subDays, eachDayOfInterval, startOfWeek } from "date-fns";
 
 interface HeatmapDay {
   day: string;
@@ -53,8 +53,7 @@ export function ActivityHeatmap() {
   // Build 52-week grid
   const today = new Date();
   const startDay = subDays(today, 364);
-  const days = eachDayOfInterval({ start: startDay, end: today });
-  
+
   // Pad to start from Sunday
   const firstDayOfWeek = startOfWeek(startDay, { weekStartsOn: 0 });
   const paddedDays = eachDayOfInterval({ start: firstDayOfWeek, end: today });

--- a/src/components/AgentOrgChart.tsx
+++ b/src/components/AgentOrgChart.tsx
@@ -60,40 +60,7 @@ export function AgentOrgChart({ agents }: AgentOrgChartProps) {
   // Layout algorithm: compute positions
   const positions: NodePos[] = [];
 
-  function layoutAgent(agent: Agent, level: number, col: number): number {
-    const children = getChildren(agent.id);
-    let myCol = col;
-
-    if (children.length > 0) {
-      let childCol = col;
-      for (const child of children) {
-        childCol = layoutAgent(child, level + 1, childCol);
-      }
-      // Center over children
-      const firstChild = positions.find((p) => p.id === children[0].id);
-      const lastChild = positions.find((p) => p.id === children[children.length - 1].id);
-      if (firstChild && lastChild) {
-        myCol = Math.floor((firstChild.x + lastChild.x + NODE_W) / 2 - NODE_W / 2);
-      } else {
-        myCol = col;
-      }
-      return childCol;
-    } else {
-      myCol = col;
-      positions.push({
-        id: agent.id,
-        x: myCol,
-        y: level * (NODE_H + V_GAP),
-        width: NODE_W,
-        height: NODE_H,
-        agent,
-      });
-      return col + NODE_W + H_GAP;
-    }
-  }
-
-  // Two-pass: first layout leaves, then parents
-  // Simpler: DFS with position accumulator
+  // DFS layout with position accumulator
   const leafXCounter = { val: 0 };
 
   function layoutDFS(agent: Agent, level: number): void {

--- a/src/components/AgentOrgChart.tsx
+++ b/src/components/AgentOrgChart.tsx
@@ -14,7 +14,7 @@ interface Agent {
   activeSessions: number;
 }
 
-interface AgentOrganigramaProps {
+interface AgentOrgChartProps {
   agents: Agent[];
 }
 
@@ -32,7 +32,7 @@ const NODE_H = 72;
 const H_GAP = 40;
 const V_GAP = 80;
 
-export function AgentOrganigrama({ agents }: AgentOrganigramaProps) {
+export function AgentOrgChart({ agents }: AgentOrganigramaProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   if (agents.length === 0) {

--- a/src/components/AgentOrgChart.tsx
+++ b/src/components/AgentOrgChart.tsx
@@ -32,7 +32,7 @@ const NODE_H = 72;
 const H_GAP = 40;
 const V_GAP = 80;
 
-export function AgentOrgChart({ agents }: AgentOrganigramaProps) {
+export function AgentOrgChart({ agents }: AgentOrgChartProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   if (agents.length === 0) {

--- a/src/components/CronJobCard.tsx
+++ b/src/components/CronJobCard.tsx
@@ -118,7 +118,7 @@ export function CronJobCard({ job, onToggle, onDelete, onRun }: CronJobCardProps
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return "—";
     const date = new Date(dateStr);
-    return date.toLocaleString("es-ES", {
+    return date.toLocaleString("en-CA", {
       weekday: "short",
       month: "short",
       day: "numeric",
@@ -148,7 +148,7 @@ export function CronJobCard({ job, onToggle, onDelete, onRun }: CronJobCardProps
 
   const formatHistoryDate = (dateStr: string | null) => {
     if (!dateStr) return "—";
-    return new Date(dateStr).toLocaleString("es-ES", {
+    return new Date(dateStr).toLocaleString("en-CA", {
       month: "short",
       day: "numeric",
       hour: "2-digit",

--- a/src/components/CronJobModal.tsx
+++ b/src/components/CronJobModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { X, Clock, Calendar, ChevronDown, Zap } from "lucide-react";
+import { X, Calendar, ChevronDown, Zap } from "lucide-react";
 import { cronToHuman, getNextRuns, isValidCron, CRON_PRESETS } from "@/lib/cron-parser";
 import type { CronJob } from "./CronJobCard";
 

--- a/src/components/CronJobModal.tsx
+++ b/src/components/CronJobModal.tsx
@@ -13,9 +13,9 @@ interface CronJobModalProps {
 }
 
 const TIMEZONES = [
-  "UTC", "Europe/Madrid", "America/New_York", "America/Chicago",
+  "UTC", "America/Toronto", "America/New_York", "America/Chicago",
   "America/Denver", "America/Los_Angeles", "Europe/London",
-  "Europe/Paris", "Europe/Berlin", "Asia/Tokyo", "Asia/Shanghai",
+  "Europe/Paris", "Europe/Berlin", "Europe/Madrid", "Asia/Tokyo", "Asia/Shanghai",
   "Asia/Singapore", "Australia/Sydney",
 ];
 
@@ -70,7 +70,7 @@ export function CronJobModal({ isOpen, onClose, onSave, editingJob }: CronJobMod
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [schedule, setSchedule] = useState("0 9 * * *");
-  const [timezone, setTimezone] = useState("Europe/Madrid");
+  const [timezone, setTimezone] = useState("UTC");
   const [frequencyMode, setFrequencyMode] = useState<FrequencyMode>("daily");
   const [showPresets, setShowPresets] = useState(false);
   const [showTemplates, setShowTemplates] = useState(false);
@@ -96,7 +96,7 @@ export function CronJobModal({ isOpen, onClose, onSave, editingJob }: CronJobMod
         setName("");
         setDescription("");
         setSchedule("0 9 * * *");
-        setTimezone("Europe/Madrid");
+        setTimezone("UTC");
         setFrequencyMode("daily");
       }
       setErrors({});

--- a/src/components/FileBrowser.tsx
+++ b/src/components/FileBrowser.tsx
@@ -23,7 +23,6 @@ import {
   Eye,
   Code2,
   RefreshCw,
-  MoreVertical,
 } from "lucide-react";
 import { FilePreview } from "./FilePreview";
 
@@ -151,6 +150,7 @@ function EditorModal({ workspace, filePath, fileName, onClose }: EditorModalProp
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content]);
 
   return (
@@ -286,7 +286,6 @@ export function FileBrowser({ workspace, path, onNavigate, viewMode = "list" }: 
   const [showNewFolder, setShowNewFolder] = useState(false);
   const [newFileName, setNewFileName] = useState("");
   const [showNewFile, setShowNewFile] = useState(false);
-  const [actionMenu, setActionMenu] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const loadItems = useCallback(() => {
@@ -593,7 +592,6 @@ export function FileBrowser({ workspace, path, onNavigate, viewMode = "list" }: 
             {items.map((item) => {
               const Icon = getFileIcon(item.name, item.type);
               const iconColor = getFileColor(item.name, item.type);
-              const filePath = path ? `${path}/${item.name}` : item.name;
 
               return (
                 <div
@@ -601,7 +599,7 @@ export function FileBrowser({ workspace, path, onNavigate, viewMode = "list" }: 
                   className="flex md:grid md:grid-cols-12 gap-2 md:gap-4 px-3 md:px-6 py-2.5 md:py-3 cursor-pointer transition-colors hover:opacity-80 group"
                   style={{ borderBottom: "1px solid var(--border)", position: "relative" }}
                   onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = "var(--background)"; }}
-                  onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = "transparent"; setActionMenu(null); }}
+                  onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = "transparent"; }}
                 >
                   {/* Name */}
                   <div

--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -298,6 +298,7 @@ export function FilePreview({ workspace, path, name, onClose }: FilePreviewProps
 
           {!loading && !error && isImage && (
             <div className="flex items-center justify-center h-full">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={`/api/browse?workspace=${encodeURIComponent(workspace)}&path=${encodeURIComponent(path)}&raw=true`}
                 alt={name}

--- a/src/components/Notepad.tsx
+++ b/src/components/Notepad.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { StickyNote, Save, Trash2 } from "lucide-react";
+import { StickyNote, Trash2 } from "lucide-react";
 
 const STORAGE_KEY = "tenacitas-notepad";
 
@@ -31,6 +31,7 @@ export function Notepad() {
       save();
     }, 2000);
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text]);
 
   const save = () => {

--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { Bell, Check, CheckCheck, Trash2, X, Info, CheckCircle, AlertTriangle, XCircle } from "lucide-react";
-import { format, formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 
 export interface Notification {
   id: string;

--- a/src/components/Office3D/AgentDesk.tsx
+++ b/src/components/Office3D/AgentDesk.tsx
@@ -5,7 +5,6 @@ import { useFrame } from '@react-three/fiber';
 import { Text, Box } from '@react-three/drei';
 import type { Mesh } from 'three';
 import type { AgentConfig, AgentState } from './agentsConfig';
-import VoxelAvatar from './VoxelAvatar';
 import VoxelChair from './VoxelChair';
 import VoxelKeyboard from './VoxelKeyboard';
 import VoxelMacMini from './VoxelMacMini';

--- a/src/components/Office3D/AvatarModel.tsx
+++ b/src/components/Office3D/AvatarModel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useGLTF } from '@react-three/drei';
-import { Sphere } from '@react-three/drei';
+import { useGLTF, Sphere } from '@react-three/drei';
 import type { AgentConfig } from './agentsConfig';
 import { useEffect, useState } from 'react';
 
@@ -10,45 +9,37 @@ interface AvatarModelProps {
   position: [number, number, number];
 }
 
+function GLBModel({ modelPath, position }: { modelPath: string; position: [number, number, number] }) {
+  const { scene } = useGLTF(modelPath);
+  return (
+    <primitive
+      object={scene.clone()}
+      position={position}
+      scale={0.8}
+      rotation={[0, Math.PI, 0]}
+      castShadow
+      receiveShadow
+    />
+  );
+}
+
 export default function AvatarModel({ agent, position }: AvatarModelProps) {
   const modelPath = `/models/${agent.id}.glb`;
   const [exists, setExists] = useState<boolean>(false);
 
-  // Check if file exists before trying to load
   useEffect(() => {
     fetch(modelPath, { method: 'HEAD' })
       .then(res => setExists(res.ok))
       .catch(() => setExists(false));
   }, [modelPath]);
 
-  // If model doesn't exist, return fallback sphere
   if (!exists) {
     return (
-      <Sphere
-        args={[0.3, 16, 16]}
-        position={position}
-        castShadow
-      >
-        <meshStandardMaterial
-          color={agent.color}
-          emissive={agent.color}
-          emissiveIntensity={0.3}
-        />
+      <Sphere args={[0.3, 16, 16]} position={position} castShadow>
+        <meshStandardMaterial color={agent.color} emissive={agent.color} emissiveIntensity={0.3} />
       </Sphere>
     );
   }
 
-  // Load and display the GLB model
-  const { scene } = useGLTF(modelPath);
-  
-  return (
-    <primitive
-      object={scene.clone()}
-      position={position}
-      scale={0.8} // Ready Player Me avatars are ~1.8m tall, scale to fit desk
-      rotation={[0, Math.PI, 0]} // Face forward
-      castShadow
-      receiveShadow
-    />
-  );
+  return <GLBModel modelPath={modelPath} position={position} />;
 }

--- a/src/components/Office3D/FileCabinet.tsx
+++ b/src/components/Office3D/FileCabinet.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { Box, Text } from '@react-three/drei';
-import type { Mesh } from 'three';
-
 interface FileCabinetProps {
   position: [number, number, number];
   onClick?: () => void;

--- a/src/components/Office3D/FirstPersonControls.tsx
+++ b/src/components/Office3D/FirstPersonControls.tsx
@@ -11,7 +11,7 @@ interface FirstPersonControlsProps {
 
 export default function FirstPersonControls({ moveSpeed = 5 }: FirstPersonControlsProps) {
   const { camera } = useThree();
-  const controlsRef = useRef<any>(null);
+  const controlsRef = useRef<InstanceType<typeof PointerLockControls>>(null);
   
   const moveState = useRef({
     forward: false,

--- a/src/components/Office3D/FirstPersonControls.tsx
+++ b/src/components/Office3D/FirstPersonControls.tsx
@@ -23,7 +23,6 @@ export default function FirstPersonControls({ moveSpeed = 5 }: FirstPersonContro
   });
 
   const velocity = useRef(new THREE.Vector3());
-  const direction = useRef(new THREE.Vector3());
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/components/Office3D/FirstPersonControls.tsx
+++ b/src/components/Office3D/FirstPersonControls.tsx
@@ -11,7 +11,7 @@ interface FirstPersonControlsProps {
 
 export default function FirstPersonControls({ moveSpeed = 5 }: FirstPersonControlsProps) {
   const { camera } = useThree();
-  const controlsRef = useRef<InstanceType<typeof PointerLockControls>>(null);
+  const controlsRef = useRef<{ isLocked: boolean }>(null);
   
   const moveState = useRef({
     forward: false,

--- a/src/components/Office3D/FirstPersonControls.tsx
+++ b/src/components/Office3D/FirstPersonControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, type ElementRef } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
 import { PointerLockControls } from '@react-three/drei';
 import * as THREE from 'three';
@@ -11,7 +11,7 @@ interface FirstPersonControlsProps {
 
 export default function FirstPersonControls({ moveSpeed = 5 }: FirstPersonControlsProps) {
   const { camera } = useThree();
-  const controlsRef = useRef<{ isLocked: boolean }>(null);
+  const controlsRef = useRef<ElementRef<typeof PointerLockControls>>(null);
   
   const moveState = useRef({
     forward: false,

--- a/src/components/Office3D/MovingAvatar.tsx
+++ b/src/components/Office3D/MovingAvatar.tsx
@@ -70,6 +70,7 @@ export default function MovingAvatar({
   // Notificar posición inicial
   useEffect(() => {
     onPositionUpdate(agent.id, initialPos.clone());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Verificar si una posición está libre (sin colisiones)
@@ -143,6 +144,7 @@ export default function MovingAvatar({
       clearTimeout(timeout);
       clearInterval(interval);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.status]);
 
   // Mover suavemente hacia el objetivo

--- a/src/components/Office3D/Office3D.test.mjs
+++ b/src/components/Office3D/Office3D.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadTypeScriptModule(filePath) {
+  const source = fs.readFileSync(filePath, "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+
+  const loadedModule = { exports: {} };
+  new Function("exports", "module", output)(loadedModule.exports, loadedModule);
+  return loadedModule.exports;
+}
+
+test("Office3D defines initial state for every configured agent", () => {
+  const { AGENTS } = loadTypeScriptModule(path.join(__dirname, "agentsConfig.ts"));
+  const source = fs.readFileSync(path.join(__dirname, "Office3D.tsx"), "utf8");
+
+  const initialStateMatch = source.match(
+    /useState<Record<string,\s*AgentState>>\(\{([\s\S]*?)\n\s*\}\);/
+  );
+  assert.ok(initialStateMatch, "Office3D should define an initial agentStates map");
+
+  const stateKeys = new Set(
+    [...initialStateMatch[1].matchAll(/^\s*(?:(['"])([^'"]+)\1|([A-Za-z_$][\w$]*))\s*:/gm)]
+      .map((match) => match[2] || match[3])
+  );
+
+  const missing = AGENTS.map((agent) => agent.id).filter((id) => !stateKeys.has(id));
+  assert.deepEqual(missing, [], `missing initial state for: ${missing.join(", ")}`);
+});

--- a/src/components/Office3D/Office3D.tsx
+++ b/src/components/Office3D/Office3D.tsx
@@ -28,11 +28,11 @@ export default function Office3D() {
   // Mock data - TODO: Replace with real API data
   const [agentStates] = useState<Record<string, AgentState>>({
     main: { id: 'main', status: 'working', currentTask: 'Processing emails', model: 'opus', tokensPerHour: 15000, tasksInQueue: 3, uptime: 12 },
-    academic: { id: 'academic', status: 'idle', model: 'sonnet', tokensPerHour: 0, tasksInQueue: 0, uptime: 8 },
-    studio: { id: 'studio', status: 'thinking', currentTask: 'Writing YouTube script', model: 'opus', tokensPerHour: 8000, tasksInQueue: 1, uptime: 5 },
-    linkedin: { id: 'linkedin', status: 'working', currentTask: 'Drafting post', model: 'sonnet', tokensPerHour: 5000, tasksInQueue: 2, uptime: 10 },
-    social: { id: 'social', status: 'idle', model: 'sonnet', tokensPerHour: 0, tasksInQueue: 0, uptime: 7 },
-    infra: { id: 'infra', status: 'error', currentTask: 'Failed deployment', model: 'haiku', tokensPerHour: 1000, tasksInQueue: 0, uptime: 15 },
+    'agent-2': { id: 'agent-2', status: 'idle', model: 'sonnet', tokensPerHour: 0, tasksInQueue: 0, uptime: 8 },
+    'agent-3': { id: 'agent-3', status: 'thinking', currentTask: 'Writing YouTube script', model: 'opus', tokensPerHour: 8000, tasksInQueue: 1, uptime: 5 },
+    'agent-4': { id: 'agent-4', status: 'working', currentTask: 'Drafting post', model: 'sonnet', tokensPerHour: 5000, tasksInQueue: 2, uptime: 10 },
+    'agent-5': { id: 'agent-5', status: 'idle', model: 'sonnet', tokensPerHour: 0, tasksInQueue: 0, uptime: 7 },
+    'agent-6': { id: 'agent-6', status: 'error', currentTask: 'Failed deployment', model: 'haiku', tokensPerHour: 1000, tasksInQueue: 0, uptime: 15 },
   });
 
   const handleDeskClick = (agentId: string) => {

--- a/src/components/Office3D/Office3D.tsx
+++ b/src/components/Office3D/Office3D.tsx
@@ -23,7 +23,7 @@ export default function Office3D() {
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const [interactionModal, setInteractionModal] = useState<string | null>(null);
   const [controlMode, setControlMode] = useState<'orbit' | 'fps'>('orbit');
-  const [avatarPositions, setAvatarPositions] = useState<Map<string, any>>(new Map());
+  const [avatarPositions, setAvatarPositions] = useState<Map<string, Vector3>>(new Map());
   
   // Mock data - TODO: Replace with real API data
   const [agentStates] = useState<Record<string, AgentState>>({
@@ -59,7 +59,7 @@ export default function Office3D() {
     setInteractionModal(null);
   };
 
-  const handleAvatarPositionUpdate = (id: string, position: any) => {
+  const handleAvatarPositionUpdate = (id: string, position: Vector3) => {
     setAvatarPositions(prev => new Map(prev).set(id, position));
   };
 

--- a/src/components/Office3D/Office3D.tsx
+++ b/src/components/Office3D/Office3D.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Canvas } from '@react-three/fiber';
-import { OrbitControls, Sky, Environment } from '@react-three/drei';
+import { OrbitControls, Sky } from '@react-three/drei';
 import { Suspense, useState } from 'react';
 import { Vector3 } from 'three';
 import { AGENTS } from './agentsConfig';
@@ -27,10 +27,10 @@ export default function Office3D() {
   
   // Mock data - TODO: Replace with real API data
   const [agentStates] = useState<Record<string, AgentState>>({
-    main: { id: 'main', status: 'working', currentTask: 'Procesando emails', model: 'opus', tokensPerHour: 15000, tasksInQueue: 3, uptime: 12 },
+    main: { id: 'main', status: 'working', currentTask: 'Processing emails', model: 'opus', tokensPerHour: 15000, tasksInQueue: 3, uptime: 12 },
     academic: { id: 'academic', status: 'idle', model: 'sonnet', tokensPerHour: 0, tasksInQueue: 0, uptime: 8 },
-    studio: { id: 'studio', status: 'thinking', currentTask: 'Generando guión YouTube', model: 'opus', tokensPerHour: 8000, tasksInQueue: 1, uptime: 5 },
-    linkedin: { id: 'linkedin', status: 'working', currentTask: 'Redactando post', model: 'sonnet', tokensPerHour: 5000, tasksInQueue: 2, uptime: 10 },
+    studio: { id: 'studio', status: 'thinking', currentTask: 'Writing YouTube script', model: 'opus', tokensPerHour: 8000, tasksInQueue: 1, uptime: 5 },
+    linkedin: { id: 'linkedin', status: 'working', currentTask: 'Drafting post', model: 'sonnet', tokensPerHour: 5000, tasksInQueue: 2, uptime: 10 },
     social: { id: 'social', status: 'idle', model: 'sonnet', tokensPerHour: 0, tasksInQueue: 0, uptime: 7 },
     infra: { id: 'infra', status: 'error', currentTask: 'Failed deployment', model: 'haiku', tokensPerHour: 1000, tasksInQueue: 0, uptime: 15 },
   });
@@ -63,20 +63,20 @@ export default function Office3D() {
     setAvatarPositions(prev => new Map(prev).set(id, position));
   };
 
-  // Definir obstáculos (muebles)
+  // Define obstacles (furniture)
   const obstacles = [
-    // Escritorios (6)
+    // Desks (6)
     ...AGENTS.map(agent => ({
       position: new Vector3(agent.position[0], 0, agent.position[2]),
       radius: 1.5
     })),
-    // Archivador
+    // Filing cabinet
     { position: new Vector3(-8, 0, -5), radius: 0.8 },
-    // Pizarra
+    // Whiteboard
     { position: new Vector3(0, 0, -8), radius: 1.5 },
-    // Máquina de café
+    // Coffee machine
     { position: new Vector3(8, 0, -5), radius: 0.6 },
-    // Plantas
+    // Plants
     { position: new Vector3(-7, 0, 6), radius: 0.5 },
     { position: new Vector3(7, 0, 6), radius: 0.5 },
     { position: new Vector3(-9, 0, 0), radius: 0.4 },
@@ -97,20 +97,21 @@ export default function Office3D() {
             <meshStandardMaterial color="orange" />
           </mesh>
         }>
-          {/* Iluminación */}
+          {/* Lighting */}
           <Lights />
 
-          {/* Cielo y ambiente */}
+          {/* Sky and ambient */}
           <Sky sunPosition={[100, 20, 100]} />
-          <Environment preset="sunset" />
+          <ambientLight intensity={0.4} />
+          <hemisphereLight args={["#87CEEB", "#8B7355", 0.3]} />
 
-          {/* Suelo */}
+          {/* Floor */}
           <Floor />
 
-          {/* Paredes */}
+          {/* Walls */}
           <Walls />
 
-          {/* Escritorios de agentes (sin avatares) */}
+          {/* Agent desks */}
           {AGENTS.map((agent) => (
             <AgentDesk
               key={agent.id}
@@ -121,7 +122,7 @@ export default function Office3D() {
             />
           ))}
 
-          {/* Avatares móviles */}
+          {/* Moving avatars */}
           {AGENTS.map((agent) => (
             <MovingAvatar
               key={`avatar-${agent.id}`}
@@ -134,7 +135,7 @@ export default function Office3D() {
             />
           ))}
 
-          {/* Mobiliario interactivo */}
+          {/* Interactive furniture */}
           <FileCabinet
             position={[-8, 0, -5]}
             onClick={handleFileCabinetClick}
@@ -149,7 +150,7 @@ export default function Office3D() {
             onClick={handleCoffeeClick}
           />
 
-          {/* Decoración */}
+          {/* Decoration */}
           <PlantPot position={[-7, 0, 6]} size="large" />
           <PlantPot position={[7, 0, 6]} size="medium" />
           <PlantPot position={[-9, 0, 0]} size="small" />
@@ -159,7 +160,7 @@ export default function Office3D() {
             rotation={[0, 0, 0]}
           />
 
-          {/* Controles de cámara */}
+          {/* Camera controls */}
           {controlMode === 'orbit' ? (
             <OrbitControls
               enableDamping
@@ -278,23 +279,23 @@ export default function Office3D() {
         </div>
       )}
 
-      {/* Controles UI overlay */}
+      {/* UI overlay */}
       <div className="absolute top-4 left-4 bg-black/70 text-white p-4 rounded-lg backdrop-blur-sm">
         <h2 className="text-lg font-bold mb-2">🏢 The Office</h2>
         <div className="text-sm space-y-1 mb-3">
           <p><strong>Mode: {controlMode === 'orbit' ? '🖱️ Orbit' : '🎮 FPS'}</strong></p>
           {controlMode === 'orbit' ? (
             <>
-              <p>🖱️ Mouse: Rotar vista</p>
+              <p>🖱️ Mouse: Rotate view</p>
               <p>🔄 Scroll: Zoom</p>
-              <p>👆 Click: Seleccionar</p>
+              <p>👆 Click: Select</p>
             </>
           ) : (
             <>
               <p>Click to lock cursor</p>
-              <p>WASD/Arrows: Mover</p>
-              <p>Space: Subir | Shift: Bajar</p>
-              <p>Mouse: Mirar | ESC: Unlock</p>
+              <p>WASD/Arrows: Move</p>
+              <p>Space: Up | Shift: Down</p>
+              <p>Mouse: Look | ESC: Unlock</p>
             </>
           )}
         </div>
@@ -308,7 +309,7 @@ export default function Office3D() {
 
       {/* Legend */}
       <div className="absolute bottom-4 right-4 bg-black/70 text-white p-4 rounded-lg backdrop-blur-sm">
-        <h3 className="text-sm font-bold mb-2">Estados</h3>
+        <h3 className="text-sm font-bold mb-2">Status</h3>
         <div className="text-xs space-y-1">
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 bg-green-500 rounded-full"></div>

--- a/src/components/Office3D/ProceduralAvatars.tsx
+++ b/src/components/Office3D/ProceduralAvatars.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Sphere, Cylinder, Cone } from '@react-three/drei';
+import { Box, Sphere, Cylinder } from '@react-three/drei';
 import type { AgentConfig } from './agentsConfig';
 
 interface ProceduralAvatarProps {

--- a/src/components/Office3D/VoxelMacMini.tsx
+++ b/src/components/Office3D/VoxelMacMini.tsx
@@ -43,7 +43,7 @@ export default function VoxelMacMini({ position }: VoxelMacMiniProps) {
 
       {/* Base/patas de goma (4 esquinas) */}
       {[-0.08, 0.08].map(x => 
-        [-0.08, 0.08].map((z, i) => (
+        [-0.08, 0.08].map((z) => (
           <Box
             key={`foot-${x}-${z}`}
             args={[0.03, 0.005, 0.03]}

--- a/src/components/Office3D/useAvatarModel.ts
+++ b/src/components/Office3D/useAvatarModel.ts
@@ -6,27 +6,14 @@ export function useAvatarModel(agentId: string) {
   const modelPath = `/models/${agentId}.glb`;
 
   useEffect(() => {
-    // Check if model file exists
     fetch(modelPath, { method: 'HEAD' })
-      .then(response => {
-        setModelExists(response.ok);
-      })
-      .catch(() => {
-        setModelExists(false);
-      });
+      .then(response => { setModelExists(response.ok); })
+      .catch(() => { setModelExists(false); });
   }, [modelPath]);
 
-  // Only try to load if we know the model exists
-  let model = null;
-  if (modelExists === true) {
-    try {
-      const gltf = useGLTF(modelPath);
-      model = gltf.scene;
-    } catch (error) {
-      // Failed to load, use fallback
-      model = null;
-    }
-  }
+  // Always call useGLTF unconditionally (rules of hooks)
+  const gltf = useGLTF(modelPath);
+  const model = modelExists === true ? gltf.scene : null;
 
   return { model, loading: modelExists === null };
 }

--- a/src/components/RichDescription.tsx
+++ b/src/components/RichDescription.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 
-const IMAGE_EXTENSIONS = /\.(png|jpe?g|webp|gif)$/i;
 // Match absolute paths to image files
 const IMAGE_PATH_RE = /((?:\/root\/\.openclaw|\/[\w/.-]+\/\.openclaw)\/(?:workspace|media)\/\S+?\.(png|jpe?g|webp|gif))/gi;
 // Match MEDIA:/path/to/file pattern
@@ -17,6 +16,7 @@ function ImageInline({ src }: { src: string }) {
 
   return (
     <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={src}
         alt=""
@@ -44,6 +44,7 @@ function ImageInline({ src }: { src: string }) {
             cursor: "zoom-out",
           }}
         >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={src}
             alt=""

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -308,7 +308,7 @@ export function Sidebar() {
             }}
           >
             <LogOut className="w-4 h-4" />
-            <span className="text-sm">Cerrar sesión</span>
+            <span className="text-sm">Log out</span>
           </button>
         </div>
       </aside>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   GitFork,
   SquareTerminal,
   History,
+  Hash,
 } from "lucide-react";
 import { getAgentDisplayName } from "@/config/branding";
 
@@ -44,6 +45,7 @@ const navItems = [
   { href: "/activity", label: "Activity", icon: Activity },
   { href: "/memory", label: "Memory", icon: Brain },
   { href: "/files", label: "Files", icon: FolderOpen },
+  { href: "/channels", label: "Slack", icon: Hash },
   { href: "/cron", label: "Cron Jobs", icon: Timer },
   { href: "/sessions", label: "Sessions", icon: History },
   { href: "/search", label: "Search", icon: Search },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,6 +29,7 @@ import {
   SquareTerminal,
   History,
   Hash,
+  Kanban,
 } from "lucide-react";
 import { getAgentDisplayName } from "@/config/branding";
 
@@ -46,6 +47,7 @@ const navItems = [
   { href: "/memory", label: "Memory", icon: Brain },
   { href: "/files", label: "Files", icon: FolderOpen },
   { href: "/channels", label: "Slack", icon: Hash },
+  { href: "/jira", label: "Jira Board", icon: Kanban },
   { href: "/cron", label: "Cron Jobs", icon: Timer },
   { href: "/sessions", label: "Sessions", icon: History },
   { href: "/search", label: "Search", icon: Search },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,7 +21,6 @@ import {
   X,
   Users,
   Gamepad2,
-  GitBranch,
   Workflow,
   Zap,
   Server,

--- a/src/components/SlackChannelCard.tsx
+++ b/src/components/SlackChannelCard.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import { ExternalLink, ChevronDown, ChevronRight } from "lucide-react";
+import type { SlackMessage, SlackUserInfo } from "@/lib/slack";
+
+interface SlackChannelCardProps {
+  name: string;
+  channelId: string | null;
+  messages: Array<SlackMessage & { userInfo?: SlackUserInfo | null }>;
+  error?: string;
+}
+
+function fmtSlackTs(ts: string): string {
+  const ms = parseFloat(ts) * 1000;
+  return new Date(ms).toLocaleTimeString("en-CA", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function slackUrl(channelId: string | null): string {
+  return channelId
+    ? `https://app.slack.com/client/${channelId}`
+    : "https://app.slack.com";
+}
+
+export function SlackChannelCard({
+  name,
+  channelId,
+  messages,
+  error,
+}: SlackChannelCardProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const latestTs = messages[0]?.ts;
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{
+        backgroundColor: "var(--card)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      {/* Header */}
+      <button
+        onClick={() => setCollapsed((v) => !v)}
+        className="w-full flex items-center justify-between px-5 py-3"
+        style={{ borderBottom: collapsed ? "none" : "1px solid var(--border)", cursor: "pointer", background: "none", border: "none" }}
+      >
+        <div className="flex items-center gap-2">
+          {collapsed ? (
+            <ChevronRight className="w-4 h-4" style={{ color: "var(--text-muted)" }} />
+          ) : (
+            <ChevronDown className="w-4 h-4" style={{ color: "var(--text-muted)" }} />
+          )}
+          <span
+            className="font-mono font-semibold"
+            style={{ color: "var(--text-primary)", fontSize: "13px" }}
+          >
+            {name}
+          </span>
+          {error && (
+            <span
+              style={{
+                fontSize: "11px",
+                color: "var(--negative)",
+                backgroundColor: "color-mix(in srgb, var(--negative) 12%, transparent)",
+                padding: "2px 6px",
+                borderRadius: "4px",
+              }}
+            >
+              unavailable
+            </span>
+          )}
+          {!error && (
+            <span
+              style={{
+                fontSize: "11px",
+                color: "var(--text-muted)",
+                backgroundColor: "var(--surface-elevated)",
+                padding: "2px 6px",
+                borderRadius: "4px",
+              }}
+            >
+              {messages.length} messages
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {latestTs && (
+            <span style={{ fontSize: "11px", color: "var(--text-muted)" }}>
+              {fmtSlackTs(latestTs)}
+            </span>
+          )}
+          <a
+            href={slackUrl(channelId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            style={{ color: "var(--text-muted)" }}
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+          </a>
+        </div>
+      </button>
+
+      {/* Messages */}
+      {!collapsed && (
+        <div>
+          {error && (
+            <p
+              className="px-5 py-3 text-sm italic"
+              style={{ color: "var(--text-muted)" }}
+            >
+              {error}
+            </p>
+          )}
+          {!error && messages.length === 0 && (
+            <p
+              className="px-5 py-3 text-sm italic"
+              style={{ color: "var(--text-muted)" }}
+            >
+              No recent messages.
+            </p>
+          )}
+          {messages.map((msg, i) => {
+            const isBot = !!(msg.botId ?? msg.userInfo?.isBot);
+            const displayName =
+              msg.userInfo?.displayName ?? msg.username ?? msg.user ?? "Unknown";
+
+            return (
+              <div
+                key={msg.ts}
+                className="flex gap-3 px-5 py-2.5"
+                style={{
+                  borderTop: i === 0 ? "1px solid var(--border)" : "none",
+                  borderBottom: "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
+                  backgroundColor: isBot
+                    ? "color-mix(in srgb, var(--accent) 4%, transparent)"
+                    : "transparent",
+                }}
+              >
+                {/* Avatar */}
+                {msg.userInfo?.avatarUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={msg.userInfo.avatarUrl}
+                    alt={displayName}
+                    className="w-7 h-7 rounded flex-shrink-0 mt-0.5"
+                  />
+                ) : (
+                  <div
+                    className="w-7 h-7 rounded flex-shrink-0 mt-0.5 flex items-center justify-center text-xs font-bold"
+                    style={{
+                      backgroundColor: "var(--surface-elevated)",
+                      color: "var(--text-muted)",
+                    }}
+                  >
+                    {displayName[0]?.toUpperCase() ?? "?"}
+                  </div>
+                )}
+
+                {/* Content */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span
+                      className="text-xs font-semibold"
+                      style={{
+                        color: isBot ? "var(--accent)" : "var(--text-secondary)",
+                      }}
+                    >
+                      {displayName}
+                      {isBot && (
+                        <span
+                          className="ml-1 font-mono font-normal"
+                          style={{ color: "var(--text-muted)", fontSize: "10px" }}
+                        >
+                          APP
+                        </span>
+                      )}
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{ fontSize: "10px", color: "var(--text-muted)" }}
+                    >
+                      {fmtSlackTs(msg.ts)}
+                    </span>
+                  </div>
+                  <p
+                    className="text-xs break-words"
+                    style={{ color: "var(--text-primary)", lineHeight: "1.5" }}
+                  >
+                    {msg.text}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TenacitOS/Dock.tsx
+++ b/src/components/TenacitOS/Dock.tsx
@@ -15,6 +15,8 @@ import {
   DollarSign,
   Settings,
   History,
+  Hash,
+  Kanban,
 } from "lucide-react";
 
 const dockItems = [
@@ -25,6 +27,8 @@ const dockItems = [
   { href: "/agents", label: "Agents", icon: Bot },
   { href: "/office", label: "Office", icon: Building2 },
   { href: "/activity", label: "Activity", icon: Activity },
+  { href: "/channels", label: "Slack", icon: Hash },
+  { href: "/jira", label: "Jira Board", icon: Kanban },
   { href: "/cron", label: "Cron Jobs", icon: Clock },
   { href: "/sessions", label: "Sessions", icon: History },
   { href: "/skills", label: "Skills", icon: Puzzle },

--- a/src/components/TenacitOS/MetricCard.tsx
+++ b/src/components/TenacitOS/MetricCard.tsx
@@ -4,7 +4,6 @@
  */
 
 import { LucideIcon } from "lucide-react";
-import { ReactNode } from "react";
 
 interface MetricCardProps {
   icon: LucideIcon;

--- a/src/components/TenacitOS/StatusBar.tsx
+++ b/src/components/TenacitOS/StatusBar.tsx
@@ -52,7 +52,7 @@ export function StatusBar() {
   const diskColor = diskPercent < 60 ? "var(--positive)" : diskPercent < 85 ? "var(--warning)" : "var(--negative)";
 
   // StatusMetric component
-  const StatusMetric = ({ icon: Icon, label, value, barPercent, color }: { icon: React.ElementType; label: string; value: string; barPercent: number; color: string }) => (
+  const StatusMetric = ({ icon: Icon, label, value, barPercent, color }: { icon: React.ComponentType<{ style?: React.CSSProperties }>; label: string; value: string; barPercent: number; color: string }) => (
     <div className="flex items-center gap-1.5" style={{ height: "24px" }}>
       <Icon style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
       <span

--- a/src/components/TenacitOS/StatusBar.tsx
+++ b/src/components/TenacitOS/StatusBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Cpu, HardDrive, MemoryStick, Shield, ShieldCheck, Clock } from "lucide-react";
 
 interface SystemStats {
@@ -52,7 +52,7 @@ export function StatusBar() {
   const diskColor = diskPercent < 60 ? "var(--positive)" : diskPercent < 85 ? "var(--warning)" : "var(--negative)";
 
   // StatusMetric component
-  const StatusMetric = ({ icon: Icon, label, value, barPercent, color }: any) => (
+  const StatusMetric = ({ icon: Icon, label, value, barPercent, color }: { icon: React.ElementType; label: string; value: string; barPercent: number; color: string }) => (
     <div className="flex items-center gap-1.5" style={{ height: "24px" }}>
       <Icon style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
       <span

--- a/src/components/TenacitOS/StatusBar.tsx
+++ b/src/components/TenacitOS/StatusBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Cpu, HardDrive, MemoryStick, Shield, ShieldCheck, Clock } from "lucide-react";
+import { Cpu, HardDrive, MemoryStick, ShieldCheck, Clock } from "lucide-react";
 
 interface SystemStats {
   cpu: number;

--- a/src/components/TenacitOS/TopBar.tsx
+++ b/src/components/TenacitOS/TopBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Search, Bell, User, Command } from "lucide-react";
+import { Search } from "lucide-react";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { NotificationDropdown } from "@/components/NotificationDropdown";
 

--- a/src/components/TenacitOS/TopBar.tsx
+++ b/src/components/TenacitOS/TopBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Search, User, Key, ImageIcon, LogOut, ChevronDown } from "lucide-react";
+import { Search, Key, ImageIcon, ChevronDown } from "lucide-react";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { NotificationDropdown } from "@/components/NotificationDropdown";
 import { ChangePasswordModal } from "@/components/ChangePasswordModal";

--- a/src/components/TenacitOS/TopBar.tsx
+++ b/src/components/TenacitOS/TopBar.tsx
@@ -1,12 +1,54 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Search } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { Search, User, Key, ImageIcon, LogOut, ChevronDown } from "lucide-react";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { NotificationDropdown } from "@/components/NotificationDropdown";
+import { ChangePasswordModal } from "@/components/ChangePasswordModal";
+import { BRANDING } from "@/config/branding";
 
 export function TopBar() {
   const [showSearch, setShowSearch] = useState(false);
+  const [showProfileMenu, setShowProfileMenu] = useState(false);
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [showAvatarModal, setShowAvatarModal] = useState(false);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [avatarUploading, setAvatarUploading] = useState(false);
+  const profileMenuRef = useRef<HTMLDivElement>(null);
+
+  // Load avatar
+  useEffect(() => {
+    fetch("/api/auth/avatar")
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.url) setAvatarUrl(d.url); })
+      .catch(() => {});
+  }, []);
+
+  // Close profile menu on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (profileMenuRef.current && !profileMenuRef.current.contains(e.target as Node)) {
+        setShowProfileMenu(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const handleAvatarUpload = async (file: File) => {
+    setAvatarUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/auth/avatar", { method: "POST", body: fd });
+      if (res.ok) {
+        const d = await res.json();
+        setAvatarUrl(d.url + "?t=" + Date.now());
+        setShowAvatarModal(false);
+      }
+    } catch {}
+    setAvatarUploading(false);
+  };
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -118,44 +160,107 @@ export function TopBar() {
           <NotificationDropdown />
 
           {/* User Area */}
-          <div className="flex items-center gap-2">
-            {/* Avatar */}
-            <div
-              style={{
-                width: "28px",
-                height: "28px",
-                borderRadius: "14px",
-                backgroundColor: "var(--accent)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
+          <div ref={profileMenuRef} style={{ position: "relative" }}>
+            <button
+              onClick={() => setShowProfileMenu(v => !v)}
+              className="flex items-center gap-2"
+              style={{ background: "none", border: "none", cursor: "pointer", padding: "4px 6px", borderRadius: "6px" }}
+              onMouseEnter={e => (e.currentTarget.style.backgroundColor = "var(--surface-elevated)")}
+              onMouseLeave={e => (e.currentTarget.style.backgroundColor = "transparent")}
             >
-              <span
+              {/* Avatar */}
+              <div
                 style={{
-                  fontFamily: "var(--font-heading)",
-                  fontSize: "12px",
-                  fontWeight: 700,
-                  color: "var(--text-primary)",
+                  width: "28px",
+                  height: "28px",
+                  borderRadius: "14px",
+                  backgroundColor: "var(--accent)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  overflow: "hidden",
+                  flexShrink: 0,
                 }}
               >
-                C
+                {avatarUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={avatarUrl} alt="avatar" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                ) : (
+                  <span style={{ fontFamily: "var(--font-heading)", fontSize: "12px", fontWeight: 700, color: "var(--text-primary)" }}>
+                    {BRANDING.ownerUsername.charAt(0).toUpperCase()}
+                  </span>
+                )}
+              </div>
+              {/* Name */}
+              <span style={{ fontFamily: "var(--font-body)", fontSize: "12px", fontWeight: 500, color: "var(--text-secondary)" }}>
+                {BRANDING.ownerUsername}
               </span>
-            </div>
-            {/* Name */}
-            <span
-              style={{
-                fontFamily: "var(--font-body)",
-                fontSize: "12px",
-                fontWeight: 500,
-                color: "var(--text-secondary)",
-              }}
-            >
-              Carlos
-            </span>
+              <ChevronDown style={{ width: "12px", height: "12px", color: "var(--text-muted)" }} />
+            </button>
+
+            {/* Profile Dropdown */}
+            {showProfileMenu && (
+              <div style={{
+                position: "absolute", top: "calc(100% + 6px)", right: 0,
+                minWidth: "180px", backgroundColor: "var(--surface)", border: "1px solid var(--border)",
+                borderRadius: "8px", boxShadow: "0 8px 24px rgba(0,0,0,0.4)", zIndex: 100, overflow: "hidden",
+              }}>
+                <div style={{ padding: "10px 14px 8px", borderBottom: "1px solid var(--border)" }}>
+                  <div style={{ fontSize: "12px", fontWeight: 600, color: "var(--text-primary)" }}>{BRANDING.ownerUsername}</div>
+                  <div style={{ fontSize: "11px", color: "var(--text-muted)" }}>Administrator</div>
+                </div>
+                {[
+                  { icon: ImageIcon, label: "Change Profile Picture", action: () => { setShowAvatarModal(true); setShowProfileMenu(false); } },
+                  { icon: Key, label: "Change Password", action: () => { setShowPasswordModal(true); setShowProfileMenu(false); } },
+                ].map(({ icon: Icon, label, action }) => (
+                  <button
+                    key={label}
+                    onClick={action}
+                    className="flex items-center gap-2 w-full text-left"
+                    style={{
+                      padding: "9px 14px", background: "none", border: "none", cursor: "pointer",
+                      fontSize: "13px", color: "var(--text-secondary)", transition: "all 120ms",
+                    }}
+                    onMouseEnter={e => { e.currentTarget.style.backgroundColor = "var(--surface-elevated)"; e.currentTarget.style.color = "var(--text-primary)"; }}
+                    onMouseLeave={e => { e.currentTarget.style.backgroundColor = "transparent"; e.currentTarget.style.color = "var(--text-secondary)"; }}
+                  >
+                    <Icon style={{ width: "14px", height: "14px" }} />
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>
+
+      {/* Change Password Modal */}
+      <ChangePasswordModal
+        isOpen={showPasswordModal}
+        onClose={() => setShowPasswordModal(false)}
+        onSuccess={() => setShowPasswordModal(false)}
+      />
+
+      {/* Avatar Upload Modal */}
+      {showAvatarModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ backgroundColor: "rgba(0,0,0,0.6)" }} onClick={() => setShowAvatarModal(false)}>
+          <div style={{ backgroundColor: "var(--surface)", border: "1px solid var(--border)", borderRadius: "12px", padding: "24px", maxWidth: "360px", width: "100%", margin: "0 16px" }} onClick={e => e.stopPropagation()}>
+            <h2 style={{ fontFamily: "var(--font-heading)", fontSize: "18px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "8px" }}>Change Profile Picture</h2>
+            <p style={{ fontSize: "13px", color: "var(--text-secondary)", marginBottom: "20px" }}>Upload a PNG, JPG, or WebP image (max 2MB).</p>
+            <label style={{ display: "block", padding: "32px", border: "2px dashed var(--border)", borderRadius: "8px", textAlign: "center", cursor: "pointer", color: "var(--text-muted)", fontSize: "13px" }}>
+              {avatarUploading ? "Uploading..." : "Click or drag to upload"}
+              <input
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                style={{ display: "none" }}
+                disabled={avatarUploading}
+                onChange={e => { const f = e.target.files?.[0]; if (f) handleAvatarUpload(f); }}
+              />
+            </label>
+            <button onClick={() => setShowAvatarModal(false)} style={{ marginTop: "16px", width: "100%", padding: "10px", borderRadius: "8px", border: "1px solid var(--border)", background: "none", cursor: "pointer", color: "var(--text-secondary)", fontSize: "13px" }}>Cancel</button>
+          </div>
+        </div>
+      )}
 
       {/* Global Search Modal */}
       {showSearch && (

--- a/src/components/charts/ActivityLineChart.tsx
+++ b/src/components/charts/ActivityLineChart.tsx
@@ -6,8 +6,6 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-  AreaChart,
-  Area,
   BarChart,
   Bar,
 } from "recharts";

--- a/src/components/office/OfficeCanvas.tsx
+++ b/src/components/office/OfficeCanvas.tsx
@@ -167,6 +167,7 @@ export function OfficeCanvas({ agents }: OfficeCanvasProps) {
         cancelAnimationFrame(animationFrameRef.current);
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agents, hoveredAgent, imagesLoaded, bgImage, spriteImages]);
 
   const render = (ctx: CanvasRenderingContext2D, time: number) => {

--- a/src/components/office/OfficeCanvas.tsx
+++ b/src/components/office/OfficeCanvas.tsx
@@ -499,7 +499,7 @@ export function OfficeCanvas({ agents }: OfficeCanvasProps) {
           letterSpacing: "4px",
         }}
       >
-        ${BRANDING.companyName}
+        {BRANDING.companyName}
       </h2>
       <canvas
         ref={canvasRef}

--- a/src/lib/agents-config.ts
+++ b/src/lib/agents-config.ts
@@ -1,0 +1,20 @@
+export interface AgentDef {
+  slug: string;
+  name: string;
+  emoji: string;
+  color: string;
+  cronNames: string[];
+}
+
+export const AGENT_DEFS: AgentDef[] = [
+  { slug: "main",        name: "Max",   emoji: "🧠", color: "#ff6b35", cronNames: [] },
+  { slug: "inbox",       name: "Iris",  emoji: "📥", color: "#6366f1", cronNames: ["inbox-classify", "inbox-surface"] },
+  { slug: "brief",       name: "Quinn", emoji: "📅", color: "#0ea5e9", cronNames: ["brief-daily"] },
+  { slug: "ghostwriter", name: "Echo",  emoji: "✍️", color: "#8b5cf6", cronNames: ["ghostwriter-weekly"] },
+  { slug: "qa",          name: "Vale",  emoji: "🔍", color: "#10b981", cronNames: [] },
+  { slug: "playsmith",   name: "Pixel", emoji: "🎮", color: "#f59e0b", cronNames: ["playsmith-saturday"] },
+];
+
+export function agentDefBySlug(slug: string): AgentDef | undefined {
+  return AGENT_DEFS.find((a) => a.slug === slug);
+}

--- a/src/lib/cron-parser.ts
+++ b/src/lib/cron-parser.ts
@@ -198,7 +198,8 @@ export function getNextRuns(
   expr: string,
   count: number = 3,
   fromDate: Date = new Date(),
-  timezone: string = 'UTC'
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _timezone: string = 'UTC'
 ): Date[] {
   const parts = parseCron(expr);
   if (!parts) return [];

--- a/src/lib/gateway.ts
+++ b/src/lib/gateway.ts
@@ -41,6 +41,9 @@ export async function callGateway<T>(method: string, params?: unknown): Promise<
     const ws = new WebSocket(gatewayWsUrl(), {
       headers: {
         Authorization: `Bearer ${gatewayToken}`,
+        // Browsers always send Origin; ws library doesn't. Gateway requires an
+        // allowed origin for operator connections, so we mimic the Control UI.
+        Origin: process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3140",
       },
     });
 

--- a/src/lib/gateway.ts
+++ b/src/lib/gateway.ts
@@ -1,0 +1,197 @@
+import WebSocket from "ws";
+
+export class GatewayError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GatewayError";
+  }
+}
+
+type RequestFrame = {
+  type: "req";
+  id: string;
+  method: string;
+  params?: unknown;
+};
+
+type ResponseFrame = {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload?: unknown;
+  error?: { message: string; code?: string };
+};
+
+type GatewayFrame = RequestFrame | ResponseFrame | { type: "event"; [k: string]: unknown };
+
+const GATEWAY_TIMEOUT_MS = 30_000;
+
+function gatewayWsUrl(): string {
+  const base = process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789";
+  return base.replace(/^http/, "ws");
+}
+
+export async function callGateway<T>(method: string, params?: unknown): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN ?? "";
+
+    const ws = new WebSocket(gatewayWsUrl(), {
+      headers: {
+        Authorization: `Bearer ${gatewayToken}`,
+      },
+    });
+
+    const timer = setTimeout(() => {
+      ws.terminate();
+      reject(new GatewayError("timeout", `Gateway request timed out: ${method}`));
+    }, GATEWAY_TIMEOUT_MS);
+
+    const pending = new Map<string, (frame: ResponseFrame) => void>();
+
+    function send(frame: RequestFrame) {
+      ws.send(JSON.stringify(frame));
+    }
+
+    function newId() {
+      return Math.random().toString(36).slice(2);
+    }
+
+    function doCall() {
+      const id = newId();
+      pending.set(id, (res) => {
+        clearTimeout(timer);
+        ws.close();
+        if (res.ok) {
+          resolve(res.payload as T);
+        } else {
+          reject(
+            new GatewayError(
+              res.error?.code ?? "gateway_error",
+              res.error?.message ?? "Gateway error",
+            ),
+          );
+        }
+      });
+      send({ type: "req", id, method, params });
+    }
+
+    const connectId = newId();
+    let connected = false;
+
+    ws.on("open", () => {
+      send({
+        type: "req",
+        id: connectId,
+        method: "connect",
+        params: {
+          minProtocol: 4,
+          maxProtocol: 4,
+          client: {
+            id: "tenacitos",
+            displayName: "NeuralOps Mission Control",
+            version: "1.0.0",
+            platform: "server",
+            mode: "backend",
+          },
+          role: "operator",
+          scopes: ["operator.read", "operator.write", "operator.admin"],
+          auth: { token: gatewayToken },
+        },
+      });
+    });
+
+    ws.on("message", (raw) => {
+      let frame: GatewayFrame;
+      try {
+        frame = JSON.parse(raw.toString()) as GatewayFrame;
+      } catch {
+        return;
+      }
+
+      if (frame.type === "res") {
+        const res = frame as ResponseFrame;
+        if (res.id === connectId) {
+          if (!res.ok) {
+            clearTimeout(timer);
+            ws.close();
+            reject(
+              new GatewayError("connect_failed", res.error?.message ?? "Gateway connect failed"),
+            );
+            return;
+          }
+          connected = true;
+          doCall();
+          return;
+        }
+        const handler = pending.get(res.id);
+        if (handler) {
+          pending.delete(res.id);
+          handler(res);
+        }
+      }
+    });
+
+    ws.on("error", (err) => {
+      clearTimeout(timer);
+      reject(new GatewayError("ws_error", err.message));
+    });
+
+    ws.on("close", () => {
+      if (!connected) {
+        clearTimeout(timer);
+        reject(new GatewayError("ws_closed", "Gateway WebSocket closed before connect"));
+      }
+    });
+  });
+}
+
+export async function checkGatewayHealth(): Promise<{ ok: boolean; latencyMs: number }> {
+  const start = Date.now();
+  try {
+    const res = await fetch(
+      `${process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789"}/health`,
+      {
+        headers: { Authorization: `Bearer ${process.env.OPENCLAW_GATEWAY_TOKEN ?? ""}` },
+        cache: "no-store",
+      },
+    );
+    return { ok: res.ok, latencyMs: Date.now() - start };
+  } catch {
+    return { ok: false, latencyMs: Date.now() - start };
+  }
+}
+
+export interface CronJobState {
+  nextRunAtMs?: number;
+  lastRunAtMs?: number;
+  lastRunStatus?: "ok" | "error" | "skipped";
+  lastError?: string;
+  runningAtMs?: number;
+}
+
+export interface CronSchedule {
+  kind: "cron" | "every" | "at";
+  expr?: string;
+  tz?: string;
+  everyMs?: number;
+  at?: string;
+}
+
+export interface CronJob {
+  id: string;
+  name: string;
+  agentId?: string;
+  enabled: boolean;
+  schedule: CronSchedule;
+  state: CronJobState;
+  payload?: Record<string, unknown>;
+  sessionTarget?: string;
+}
+
+export interface CronListResult {
+  jobs: CronJob[];
+  total?: number;
+}

--- a/src/lib/gateway.ts
+++ b/src/lib/gateway.ts
@@ -90,7 +90,7 @@ export async function callGateway<T>(method: string, params?: unknown): Promise<
           minProtocol: 4,
           maxProtocol: 4,
           client: {
-            id: "tenacitos",
+            id: "openclaw-control-ui",
             displayName: "NeuralOps Mission Control",
             version: "1.0.0",
             platform: "server",

--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -1,0 +1,134 @@
+export const JIRA_COLUMNS = ["To Do", "In Progress", "Done"] as const;
+export type JiraStatus = (typeof JIRA_COLUMNS)[number];
+
+export interface JiraIssue {
+  id: string;
+  key: string;
+  summary: string;
+  status: string;
+  priority: string;
+  issuetype: string;
+  assignee: { displayName: string; avatarUrl: string } | null;
+  url: string;
+}
+
+function jiraAuthHeader(): string {
+  const creds = `${process.env.JIRA_USER ?? ""}:${process.env.JIRA_API_TOKEN ?? ""}`;
+  return `Basic ${Buffer.from(creds).toString("base64")}`;
+}
+
+function jiraBase(): string {
+  return (process.env.JIRA_BASE_URL ?? "").replace(/\/$/, "");
+}
+
+export async function getProjectIssues(project: string): Promise<JiraIssue[]> {
+  const jql = `project = ${project} ORDER BY updated DESC`;
+
+  const res = await fetch(`${jiraBase()}/rest/api/3/search/jql`, {
+    method: "POST",
+    headers: {
+      Authorization: jiraAuthHeader(),
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      jql,
+      maxResults: 100,
+      fields: ["summary", "status", "priority", "assignee", "issuetype"],
+    }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Jira fetch failed: ${res.status} — ${body.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as {
+    issues: Array<{
+      id: string;
+      key: string;
+      fields: {
+        summary: string;
+        status: { name: string };
+        priority: { name: string };
+        issuetype: { name: string };
+        assignee: {
+          displayName: string;
+          avatarUrls: { "24x24": string };
+        } | null;
+      };
+    }>;
+  };
+
+  return data.issues.map((issue) => ({
+    id: issue.id,
+    key: issue.key,
+    summary: issue.fields.summary,
+    status: issue.fields.status.name,
+    priority: issue.fields.priority?.name ?? "Medium",
+    issuetype: issue.fields.issuetype?.name ?? "Task",
+    assignee: issue.fields.assignee
+      ? {
+          displayName: issue.fields.assignee.displayName,
+          avatarUrl: issue.fields.assignee.avatarUrls["24x24"],
+        }
+      : null,
+    url: `${jiraBase()}/browse/${issue.key}`,
+  }));
+}
+
+export async function transitionIssue(
+  issueKey: string,
+  transitionId: string,
+): Promise<void> {
+  const res = await fetch(`${jiraBase()}/rest/api/3/issue/${issueKey}/transitions`, {
+    method: "POST",
+    headers: {
+      Authorization: jiraAuthHeader(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ transition: { id: transitionId } }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Jira transition failed: ${res.status}`);
+  }
+}
+
+export async function getTransitions(
+  issueKey: string,
+): Promise<Array<{ id: string; name: string }>> {
+  const res = await fetch(`${jiraBase()}/rest/api/3/issue/${issueKey}/transitions`, {
+    headers: {
+      Authorization: jiraAuthHeader(),
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) return [];
+  const data = (await res.json()) as { transitions: Array<{ id: string; name: string }> };
+  return data.transitions;
+}
+
+export function priorityColor(priority: string): string {
+  const p = priority.toLowerCase();
+  if (p === "highest" || p === "blocker") return "#ef4444";
+  if (p === "high") return "#f97316";
+  if (p === "medium") return "#eab308";
+  if (p === "low") return "#3b82f6";
+  return "#6b7280";
+}
+
+export function priorityIcon(priority: string): string {
+  const p = priority.toLowerCase();
+  if (p === "highest" || p === "blocker") return "🔴";
+  if (p === "high") return "🟠";
+  if (p === "medium") return "🟡";
+  if (p === "low") return "🔵";
+  return "⚪";
+}
+
+export function jiraBoardUrl(project: string): string {
+  return `${jiraBase()}/jira/software/projects/${project}/boards`;
+}

--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -132,3 +132,61 @@ export function priorityIcon(priority: string): string {
 export function jiraBoardUrl(project: string): string {
   return `${jiraBase()}/jira/software/projects/${project}/boards`;
 }
+
+export async function getSingleIssue(issueKey: string): Promise<JiraIssue | null> {
+  const res = await fetch(
+    `${jiraBase()}/rest/api/3/issue/${issueKey}?fields=summary,status,priority,assignee,issuetype`,
+    {
+      headers: { Authorization: jiraAuthHeader(), Accept: "application/json" },
+      cache: "no-store",
+    },
+  );
+  if (!res.ok) return null;
+  const issue = (await res.json()) as {
+    id: string;
+    key: string;
+    fields: {
+      summary: string;
+      status: { name: string };
+      priority: { name: string };
+      issuetype: { name: string };
+      assignee: { displayName: string; avatarUrls: { "24x24": string } } | null;
+    };
+  };
+  return {
+    id: issue.id,
+    key: issue.key,
+    summary: issue.fields.summary,
+    status: issue.fields.status.name,
+    priority: issue.fields.priority?.name ?? "Medium",
+    issuetype: issue.fields.issuetype?.name ?? "Task",
+    assignee: issue.fields.assignee
+      ? {
+          displayName: issue.fields.assignee.displayName,
+          avatarUrl: issue.fields.assignee.avatarUrls["24x24"],
+        }
+      : null,
+    url: `${jiraBase()}/browse/${issue.key}`,
+  };
+}
+
+export async function addJiraComment(issueKey: string, body: string): Promise<void> {
+  const res = await fetch(`${jiraBase()}/rest/api/3/issue/${issueKey}/comment`, {
+    method: "POST",
+    headers: {
+      Authorization: jiraAuthHeader(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      body: {
+        type: "doc",
+        version: 1,
+        content: [{ type: "paragraph", content: [{ type: "text", text: body }] }],
+      },
+    }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Jira comment failed: ${res.status}`);
+  }
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,51 @@
+import fs from "fs/promises";
+import path from "path";
+import { randomUUID } from "crypto";
+
+const DATA_PATH = path.join(process.cwd(), "data", "notifications.json");
+
+export interface Notification {
+  id: string;
+  timestamp: string;
+  title: string;
+  message: string;
+  type: "info" | "success" | "warning" | "error";
+  read: boolean;
+  link?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function loadNotifications(): Promise<Notification[]> {
+  try {
+    const data = await fs.readFile(DATA_PATH, "utf-8");
+    return JSON.parse(data) as Notification[];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveNotifications(notifications: Notification[]): Promise<void> {
+  const dir = path.dirname(DATA_PATH);
+  try {
+    await fs.access(dir);
+  } catch {
+    await fs.mkdir(dir, { recursive: true });
+  }
+  await fs.writeFile(DATA_PATH, JSON.stringify(notifications, null, 2));
+}
+
+export async function createNotification(
+  input: Omit<Notification, "id" | "timestamp" | "read">,
+): Promise<Notification> {
+  const notifications = await loadNotifications();
+  const notification: Notification = {
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    read: false,
+    ...input,
+  };
+  notifications.unshift(notification);
+  if (notifications.length > 100) notifications.splice(100);
+  await saveNotifications(notifications);
+  return notification;
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import path from 'path';
 
 /**
@@ -38,7 +39,6 @@ export function resolveWorkspacePath(id: string): string | null {
   if (id.startsWith('agent-')) {
     const agentId = id.slice('agent-'.length);
     try {
-      const { readFileSync } = require('fs');
       const config = JSON.parse(readFileSync(OPENCLAW_CONFIG, 'utf-8'));
       const agent = (config?.agents?.list ?? []).find(
         (a: { id: string }) => a.id === agentId,

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -22,3 +22,31 @@ export const ALLOWED_MEDIA_PREFIXES = [
   path.join(OPENCLAW_WORKSPACE, '/'),
   path.join(OPENCLAW_MEDIA, '/'),
 ];
+
+/**
+ * Resolves a workspace ID to an absolute path.
+ * Handles static IDs (workspace, mission-control) and dynamic agent-* IDs
+ * sourced from openclaw.json so that file mutations work for all workspaces.
+ */
+export function resolveWorkspacePath(id: string): string | null {
+  const staticMap: Record<string, string> = {
+    workspace: OPENCLAW_WORKSPACE,
+    'mission-control': path.join(OPENCLAW_DIR, 'workspace', 'mission-control'),
+  };
+  if (staticMap[id]) return staticMap[id];
+
+  if (id.startsWith('agent-')) {
+    const agentId = id.slice('agent-'.length);
+    try {
+      const { readFileSync } = require('fs');
+      const config = JSON.parse(readFileSync(OPENCLAW_CONFIG, 'utf-8'));
+      const agent = (config?.agents?.list ?? []).find(
+        (a: { id: string }) => a.id === agentId,
+      );
+      return agent?.workspace ?? null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}

--- a/src/lib/skill-parser.ts
+++ b/src/lib/skill-parser.ts
@@ -182,7 +182,7 @@ function buildAgentSkillMap(): Map<string, string[]> {
   let agentList: Array<{ id: string; workspace: string }> = [];
   try {
     const openclawConfig = JSON.parse(fs.readFileSync(path.join(openclawDir, 'openclaw.json'), 'utf-8'));
-    agentList = (openclawConfig?.agents?.list || []).map((a: any) => ({
+    agentList = (openclawConfig?.agents?.list || []).map((a: { id: string; workspace?: string }) => ({
       id: a.id,
       workspace: a.workspace || path.join(openclawDir, 'workspace'),
     }));

--- a/src/lib/skill-parser.ts
+++ b/src/lib/skill-parser.ts
@@ -218,19 +218,6 @@ function buildAgentSkillMap(): Map<string, string[]> {
 }
 
 /**
- * Load configured skills from config file
- */
-function loadConfiguredSkills(): ConfiguredSkill[] {
-  try {
-    const content = fs.readFileSync(CONFIG_PATH, 'utf-8');
-    const config: SkillsConfig = JSON.parse(content);
-    return config.skills || [];
-  } catch {
-    return [];
-  }
-}
-
-/**
  * Scan only configured skills and return parsed skills
  */
 export function scanAllSkills(): SkillInfo[] {

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -106,3 +106,26 @@ export async function getUserInfo(userId: string): Promise<SlackUserInfo | null>
     isBot: data.user.is_bot,
   };
 }
+
+export async function sendSlackMessage(
+  channelName: string,
+  text: string,
+  blocks?: unknown[],
+): Promise<{ ok: boolean; ts?: string; error?: string }> {
+  const channelId = await resolveChannelId(channelName);
+  if (!channelId) return { ok: false, error: `Channel not found: ${channelName}` };
+
+  const body: Record<string, unknown> = { channel: channelId, text };
+  if (blocks) body.blocks = blocks;
+
+  const res = await fetch(`${SLACK_API}/chat.postMessage`, {
+    method: "POST",
+    headers: {
+      Authorization: slackAuthHeader(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const data = (await res.json()) as { ok: boolean; ts?: string; error?: string };
+  return data;
+}

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,0 +1,108 @@
+const SLACK_API = "https://slack.com/api";
+
+export interface SlackMessage {
+  ts: string;
+  text: string;
+  user: string;
+  botId?: string;
+  username?: string;
+}
+
+export interface SlackUserInfo {
+  displayName: string;
+  avatarUrl: string;
+  isBot: boolean;
+}
+
+function slackAuthHeader(): string {
+  return `Bearer ${process.env.SLACK_BOT_TOKEN ?? ""}`;
+}
+
+const CHANNEL_IDS: Record<string, string> = {
+  "#ops": process.env.SLACK_CHANNEL_OPS ?? "",
+  "#content": process.env.SLACK_CHANNEL_CONTENT ?? "",
+  "#dev": process.env.SLACK_CHANNEL_DEV ?? "",
+  "#trading": process.env.SLACK_CHANNEL_TRADING ?? "",
+  "#roblox": process.env.SLACK_CHANNEL_ROBLOX ?? "",
+};
+
+export const SLACK_CHANNELS = Object.keys(CHANNEL_IDS);
+
+export async function resolveChannelId(channelName: string): Promise<string | null> {
+  // Try env var first (fastest)
+  if (CHANNEL_IDS[channelName]) return CHANNEL_IDS[channelName];
+
+  // Fall back to conversations.list lookup
+  const name = channelName.replace(/^#/, "");
+  let cursor: string | undefined;
+
+  for (let page = 0; page < 5; page++) {
+    const params = new URLSearchParams({
+      exclude_archived: "true",
+      types: "public_channel,private_channel",
+      limit: "200",
+    });
+    if (cursor) params.set("cursor", cursor);
+
+    const res = await fetch(`${SLACK_API}/conversations.list?${params}`, {
+      headers: { Authorization: slackAuthHeader() },
+      next: { revalidate: 3600 },
+    });
+    const data = (await res.json()) as {
+      ok: boolean;
+      channels: Array<{ id: string; name: string }>;
+      response_metadata?: { next_cursor?: string };
+    };
+    if (!data.ok) return null;
+    const match = data.channels.find((c) => c.name === name);
+    if (match) return match.id;
+    cursor = data.response_metadata?.next_cursor;
+    if (!cursor) break;
+  }
+  return null;
+}
+
+export async function getChannelHistory(
+  channelId: string,
+  limit = 10,
+): Promise<SlackMessage[]> {
+  const res = await fetch(
+    `${SLACK_API}/conversations.history?channel=${channelId}&limit=${limit}`,
+    {
+      headers: { Authorization: slackAuthHeader() },
+      next: { revalidate: 0 },
+    },
+  );
+  const data = (await res.json()) as {
+    ok: boolean;
+    messages?: SlackMessage[];
+    error?: string;
+  };
+  if (!data.ok || !data.messages) return [];
+  return data.messages;
+}
+
+export async function getUserInfo(userId: string): Promise<SlackUserInfo | null> {
+  const res = await fetch(`${SLACK_API}/users.info?user=${userId}`, {
+    headers: { Authorization: slackAuthHeader() },
+    next: { revalidate: 3600 },
+  });
+  const data = (await res.json()) as {
+    ok: boolean;
+    user?: {
+      name: string;
+      real_name: string;
+      is_bot: boolean;
+      profile: {
+        display_name: string;
+        image_48: string;
+      };
+    };
+  };
+  if (!data.ok || !data.user) return null;
+  return {
+    displayName: data.user.profile.display_name || data.user.real_name || data.user.name,
+    avatarUrl: data.user.profile.image_48,
+    isBot: data.user.is_bot,
+  };
+}

--- a/src/lib/usage-collector.ts
+++ b/src/lib/usage-collector.ts
@@ -53,7 +53,7 @@ export async function getOpenClawStatus(): Promise<unknown> {
  */
 export function extractSessionData(status: unknown): SessionData[] {
   const sessions: SessionData[] = [];
-  const s = status as { sessions?: { byAgent?: Array<{ agentId: string; recent?: Array<{ key: string; sessionId: string; model?: string; inputTokens?: number; outputTokens?: number; cost?: number }> }> } };
+  const s = status as { sessions?: { byAgent?: Array<{ agentId: string; recent?: Array<{ key: string; sessionId: string; model?: string; inputTokens?: number; outputTokens?: number; totalTokens?: number; cost?: number; updatedAt?: string; percentUsed?: number }> }> } };
 
   if (!s.sessions?.byAgent) {
     return sessions;

--- a/src/lib/usage-collector.ts
+++ b/src/lib/usage-collector.ts
@@ -71,7 +71,7 @@ export function extractSessionData(status: unknown): SessionData[] {
         inputTokens: session.inputTokens || 0,
         outputTokens: session.outputTokens || 0,
         totalTokens: session.totalTokens || 0,
-        updatedAt: session.updatedAt,
+        updatedAt: session.updatedAt ?? 0,
         percentUsed: session.percentUsed || 0,
       });
     }

--- a/src/lib/usage-collector.ts
+++ b/src/lib/usage-collector.ts
@@ -53,7 +53,7 @@ export async function getOpenClawStatus(): Promise<unknown> {
  */
 export function extractSessionData(status: unknown): SessionData[] {
   const sessions: SessionData[] = [];
-  const s = status as { sessions?: { byAgent?: Array<{ agentId: string; recent?: Array<{ key: string; sessionId: string; model?: string; inputTokens?: number; outputTokens?: number; totalTokens?: number; cost?: number; updatedAt?: string; percentUsed?: number }> }> } };
+  const s = status as { sessions?: { byAgent?: Array<{ agentId: string; recent?: Array<{ key: string; sessionId: string; model?: string; inputTokens?: number; outputTokens?: number; totalTokens?: number; cost?: number; updatedAt?: number; percentUsed?: number }> }> } };
 
   if (!s.sessions?.byAgent) {
     return sessions;

--- a/src/lib/usage-collector.ts
+++ b/src/lib/usage-collector.ts
@@ -38,7 +38,7 @@ export interface UsageSnapshot {
 /**
  * Get current OpenClaw status with session data
  */
-export async function getOpenClawStatus(): Promise<any> {
+export async function getOpenClawStatus(): Promise<unknown> {
   try {
     const { stdout } = await execAsync("openclaw status --json");
     return JSON.parse(stdout);
@@ -51,14 +51,15 @@ export async function getOpenClawStatus(): Promise<any> {
 /**
  * Extract session data from status
  */
-export function extractSessionData(status: any): SessionData[] {
+export function extractSessionData(status: unknown): SessionData[] {
   const sessions: SessionData[] = [];
+  const s = status as { sessions?: { byAgent?: Array<{ agentId: string; recent?: Array<{ key: string; sessionId: string; model?: string; inputTokens?: number; outputTokens?: number; cost?: number }> }> } };
 
-  if (!status.sessions?.byAgent) {
+  if (!s.sessions?.byAgent) {
     return sessions;
   }
 
-  for (const agentGroup of status.sessions.byAgent) {
+  for (const agentGroup of s.sessions.byAgent) {
     const agentId = agentGroup.agentId;
 
     for (const session of agentGroup.recent || []) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,7 @@ function isAuthenticated(request: NextRequest): boolean {
   return !!(authCookie && authCookie.value === process.env.AUTH_SECRET);
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Always allow public pages (login)


### PR DESCRIPTION
## Summary

Fixes the `/office` client-side crash by aligning the 3D office mock agent state map with the configured agent desk IDs.

## Root Cause

`AGENTS` defines desks for `main` and `agent-2` through `agent-6`, but `Office3D` seeded `agentStates` for legacy IDs such as `academic`, `studio`, and `infra`. Rendering an agent without a matching state passed `undefined` into `AgentDesk`, which then read `state.status` and crashed the client.

## Changes

- Updated the seeded `agentStates` keys to match `AGENTS`.
- Added a focused Node test that checks every configured office agent has an initial state entry.

## Validation

- `node --test src/components/Office3D/Office3D.test.mjs`
- `node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `npm run build`
